### PR TITLE
NMA-4943: Update to Gradle 8.1-rc-1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase = GRADLE_USER_HOME
 distributionPath = wrapper/dists
-distributionUrl = https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionUrl = https\://services.gradle.org/distributions/gradle-8.1-rc-1-bin.zip
 networkTimeout = 10000
 zipStoreBase = GRADLE_USER_HOME
 zipStorePath = wrapper/dists


### PR DESCRIPTION
Release logs: https://docs.gradle.org/8.1-rc-1/release-notes.html
