### PR TITLE
NMA-4944: Add disabled waiting list colors

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/colors/ColorsScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/colors/ColorsScreen.kt
@@ -235,6 +235,14 @@ private fun SatsColors.toListItems(): List<ListItem> {
         ColorItem("onSurface.secondary", onSurface.secondary),
         ColorItem("onSurface.disabled", onSurface.disabled),
 
+        HeaderItem("Waiting List"),
+        ColorItem("waitingList.primary", waitingList.primary),
+        ColorItem("waitingList.disabled", waitingList.disabled),
+
+        HeaderItem("On Waiting List"),
+        ColorItem("onWaitingList.primary", onWaitingList.primary),
+        ColorItem("onWaitingList.disabled", onWaitingList.disabled),
+
         HeaderItem("Rewards"),
         ColorItem("rewards.selection.blue", rewards.selection.blue),
         ColorItem("rewards.selection.silver", rewards.selection.silver),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
@@ -24,7 +24,11 @@ data class SatsColors(
     val surface: Surface,
     val onSurface: OnSurface,
     val selection: Color,
+
+    @Deprecated("Replace with one of the waitingList colors, e.g. waitingList.primary")
     val waitlist: Color,
+
+    @Deprecated("Replace with one of the onWaitingList colors, e.g. onWaitingList.primary")
     val onWaitlist: Color,
     val waitingList: WaitingList,
     val onWaitingList: OnWaitingList,

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
@@ -26,6 +26,8 @@ data class SatsColors(
     val selection: Color,
     val waitlist: Color,
     val onWaitlist: Color,
+    val waitingList: WaitingList,
+    val onWaitingList: OnWaitingList,
     val onSignal: Color,
     val rewards: Rewards,
     val workout: Workout,
@@ -160,6 +162,16 @@ data class SatsColors(
             val disabledOff: Color,
         )
     }
+
+    data class WaitingList(
+        val primary: Color,
+        val disabled: Color,
+    )
+
+    data class OnWaitingList(
+        val primary: Color,
+        val disabled: Color,
+    )
 
     data class Rewards(
         val selection: RewardsColors,

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsDark.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsDark.kt
@@ -110,6 +110,17 @@ internal val SatsDarkColors = SatsColors(
             disabledOff = Color(0x66FFFFFF),
         ),
     ),
+
+    waitingList = SatsColors.WaitingList(
+        primary = Color(0xFF686DB9),
+        disabled = Color(0xFFA0A5F1),
+    ),
+
+    onWaitingList = SatsColors.OnWaitingList(
+        primary = Color(0xFFFFFFFF),
+        disabled = Color(0xADFFFFFF),
+    ),
+
     selection = Color(0xFF9EC3FF),
     waitlist = Color(0xFF686DB9),
     onWaitlist = Color(0xFFFFFFFF),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsLight.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsLight.kt
@@ -110,6 +110,17 @@ internal val SatsLightColors = SatsColors(
             disabledOff = Color(0xFF9FB1C9),
         ),
     ),
+
+    waitingList = SatsColors.WaitingList(
+        primary = Color(0XFF484BA2),
+        disabled = Color(0XFF686DB9),
+    ),
+
+    onWaitingList = SatsColors.OnWaitingList(
+        primary = Color(0XFFFFFFFF),
+        disabled = Color(0XFFE8E9EC),
+    ),
+
     selection = Color(0xFFFA5333),
     waitlist = Color(0xFF484BA2),
     onWaitlist = Color(0xFFFFFFFF),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsPreview.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsPreview.kt
@@ -499,6 +499,30 @@ private fun SatsColors.toListItems(): List<ListItem> {
             hexCode = onSurface.disabled.toRgbaHex(),
         ),
 
+        ListItem.Header("Waiting List"),
+        ListItem.ColorItem(
+            name = "waitingList.primary",
+            color = waitingList.primary,
+            hexCode = waitingList.primary.toRgbaHex(),
+        ),
+        ListItem.ColorItem(
+            name = "waitingList.disabled",
+            color = waitingList.disabled,
+            hexCode = waitingList.disabled.toRgbaHex(),
+        ),
+
+        ListItem.Header("On Waiting List"),
+        ListItem.ColorItem(
+            name = "onWaitingList.primary",
+            color = onWaitingList.primary,
+            hexCode = onWaitingList.primary.toRgbaHex(),
+        ),
+        ListItem.ColorItem(
+            name = "onWaitingList.disabled",
+            color = onWaitingList.disabled,
+            hexCode = onWaitingList.disabled.toRgbaHex(),
+        ),
+
         ListItem.Header("Rewards"),
         ListItem.ColorItem(
             name = "rewards.selection.blue",


### PR DESCRIPTION
Made new `waitingList` and `onWaitingList` colors, so we don't break existing usages of `waitList` and `onWaitList`, and because the names are better. :sunglasses: 

We need this for waiting list buttons later. I've also deprecated `waitList` and `onWaitlist` in favor of the new colors.

See the [color specs in Figma](https://www.figma.com/file/WzKCwRY09zn4rzRVfY0YvdRt/sats-ds-styles?node-id=1-2&t=fNnPqOrIAoaLKViD-0) for reference.

|   |   |
| - | - |
| ![image](https://user-images.githubusercontent.com/386122/226632833-15052c75-b699-4f6c-b51a-584db2f20a23.png) | ![image](https://user-images.githubusercontent.com/386122/226632845-aa478821-369e-4188-9f97-1b6cf0fc1a7e.png) |
