### PR TITLE
NMA-4945: Create Sats Button Component

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.navigation
 import com.sats.dna.sample.colors.ColorsScreen
+import com.sats.dna.sample.components.buttons.ButtonsScreen
 import com.sats.dna.sample.home.HomeScreen
 import com.sats.dna.sample.icons.IconsScreen
 import com.sats.dna.sample.typography.TypographyScreen
@@ -20,6 +21,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         colorsScreen(navigateUp = navController::navigateUp)
         iconsScreen(navigateUp = navController::navigateUp)
         typographyScreen(navigateUp = navController::navigateUp)
+        buttonsScreen(navigateUp = navController::navigateUp)
     }
 }
 
@@ -47,6 +49,12 @@ private fun NavGraphBuilder.iconsScreen(navigateUp: () -> Unit) {
     }
 }
 
+private fun NavGraphBuilder.buttonsScreen(navigateUp: () -> Unit) {
+    composable("/components/buttons") {
+        ButtonsScreen(navigateUp = navigateUp)
+    }
+}
+
 internal fun NavController.navigateToColors() {
     navigate("/colors")
 }
@@ -57,4 +65,8 @@ internal fun NavController.navigateToTypography() {
 
 internal fun NavController.navigateToIcons() {
     navigate("/icons")
+}
+
+internal fun NavController.navigateToButtons() {
+    navigate("/components/buttons")
 }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/buttons/ButtonsScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/buttons/ButtonsScreen.kt
@@ -1,0 +1,163 @@
+@file:OptIn(ExperimentalMaterialApi::class)
+
+package com.sats.dna.sample.components.buttons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Arrangement.SpaceAround
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FilterChip
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.insets.ui.Scaffold
+import com.google.accompanist.insets.ui.TopAppBar
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+internal fun ButtonsScreen(navigateUp: () -> Unit) {
+    val controlPanelState = remember { ControlPanelState() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                backgroundColor = SatsTheme.colors.surface.primary,
+                contentPadding = WindowInsets.statusBars.asPaddingValues(),
+                navigationIcon = {
+                    IconButton(onClick = navigateUp) {
+                        Icon(SatsTheme.icons.back, contentDescription = null)
+                    }
+                },
+                title = { Text("Buttons") },
+            )
+        },
+        bottomBar = { ControlPanel(controlPanelState) },
+    ) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(vertical = SatsTheme.spacing.m),
+            verticalArrangement = spacedBy(SatsTheme.spacing.m),
+            horizontalAlignment = CenterHorizontally,
+        ) {
+            SatsButton(
+                onClick = {},
+                label = "Primary",
+                colors = SatsButtonColor.Primary,
+                isEnabled = controlPanelState.isEnabledToggled,
+                isLoading = controlPanelState.isLoadingToggled,
+                isLarge = controlPanelState.isLargeToggled,
+            )
+
+            SatsButton(
+                onClick = {},
+                label = "Cta",
+                colors = SatsButtonColor.Cta,
+                isEnabled = controlPanelState.isEnabledToggled,
+                isLoading = controlPanelState.isLoadingToggled,
+                isLarge = controlPanelState.isLargeToggled,
+            )
+
+            SatsButton(
+                onClick = {},
+                label = "Secondary",
+                colors = SatsButtonColor.Secondary,
+                isEnabled = controlPanelState.isEnabledToggled,
+                isLoading = controlPanelState.isLoadingToggled,
+                isLarge = controlPanelState.isLargeToggled,
+            )
+
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .background(SatsTheme.colors.primary.default)
+                    .padding(SatsTheme.spacing.l),
+                contentAlignment = Center,
+            ) {
+                SatsButton(
+                    onClick = {},
+                    label = "Clean",
+                    colors = SatsButtonColor.Clean,
+                    isEnabled = controlPanelState.isEnabledToggled,
+                    isLoading = controlPanelState.isLoadingToggled,
+                    isLarge = controlPanelState.isLargeToggled,
+                )
+            }
+
+            SatsButton(
+                onClick = {},
+                label = "WaitingList",
+                colors = SatsButtonColor.WaitingList,
+                isEnabled = controlPanelState.isEnabledToggled,
+                isLoading = controlPanelState.isLoadingToggled,
+                isLarge = controlPanelState.isLargeToggled,
+            )
+        }
+    }
+}
+
+@Stable
+private class ControlPanelState {
+    var isEnabledToggled by mutableStateOf(true)
+    var isLoadingToggled by mutableStateOf(false)
+    var isLargeToggled by mutableStateOf(false)
+}
+
+@Composable
+private fun ControlPanel(
+    state: ControlPanelState,
+) {
+    Surface(Modifier.fillMaxWidth(), elevation = 2.dp) {
+        Row(
+            Modifier
+                .navigationBarsPadding()
+                .padding(SatsTheme.spacing.m),
+            horizontalArrangement = SpaceAround,
+        ) {
+            FilterChip(
+                selected = state.isEnabledToggled,
+                onClick = { state.isEnabledToggled = !state.isEnabledToggled },
+            ) {
+                Text("Enabled")
+            }
+
+            FilterChip(
+                selected = state.isLoadingToggled,
+                onClick = { state.isLoadingToggled = !state.isLoadingToggled },
+            ) {
+                Text("Loading")
+            }
+
+            FilterChip(
+                selected = state.isLargeToggled,
+                onClick = { state.isLargeToggled = !state.isLargeToggled },
+            ) {
+                Text("Large")
+            }
+        }
+    }
+}

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ListItem
 import androidx.compose.material.Text
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import com.google.accompanist.insets.ui.Scaffold
 import com.google.accompanist.insets.ui.TopAppBar
+import com.sats.dna.sample.navigateToButtons
 import com.sats.dna.sample.navigateToColors
 import com.sats.dna.sample.navigateToIcons
 import com.sats.dna.sample.navigateToTypography
@@ -55,6 +57,13 @@ internal fun HomeScreen(navController: NavController) {
             ListItem(
                 modifier = Modifier.clickable { navController.navigateToIcons() },
                 text = { Text("Icons") },
+            )
+
+            Divider(Modifier.padding(vertical = SatsTheme.spacing.s))
+
+            ListItem(
+                modifier = Modifier.clickable { navController.navigateToButtons() },
+                text = { Text("Buttons") },
             )
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -49,7 +49,7 @@ fun SatsButton(
     }
 }
 
-enum class SatsButtonColor { Primary, Cta, Secondary, Clean }
+enum class SatsButtonColor { Primary, Cta, Secondary, Clean, WaitingList }
 
 @Composable
 private fun SatsButtonColor.toButtonColors() = when (this) {
@@ -79,6 +79,13 @@ private fun SatsButtonColor.toButtonColors() = when (this) {
         contentColor = SatsTheme.colors.onClean.default,
         disabledBackgroundColor = SatsTheme.colors.clean.disabled,
         disabledContentColor = SatsTheme.colors.onClean.disabled,
+    )
+
+    SatsButtonColor.WaitingList -> ButtonDefaults.buttonColors(
+        backgroundColor = SatsTheme.colors.waitingList.primary,
+        contentColor = SatsTheme.colors.onWaitingList.primary,
+        disabledBackgroundColor = SatsTheme.colors.waitingList.disabled,
+        disabledContentColor = SatsTheme.colors.onWaitingList.disabled,
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -49,7 +49,7 @@ fun SatsButton(
     }
 }
 
-enum class SatsButtonColor { Primary, Cta, Secondary }
+enum class SatsButtonColor { Primary, Cta, Secondary, Clean }
 
 @Composable
 private fun SatsButtonColor.toButtonColors() = when (this) {
@@ -72,6 +72,13 @@ private fun SatsButtonColor.toButtonColors() = when (this) {
         contentColor = SatsTheme.colors.onSecondary.default,
         disabledBackgroundColor = SatsTheme.colors.secondary.disabled,
         disabledContentColor = SatsTheme.colors.onSecondary.disabled,
+    )
+
+    SatsButtonColor.Clean -> ButtonDefaults.buttonColors(
+        backgroundColor = SatsTheme.colors.clean.default,
+        contentColor = SatsTheme.colors.onClean.default,
+        disabledBackgroundColor = SatsTheme.colors.clean.disabled,
+        disabledContentColor = SatsTheme.colors.onClean.disabled,
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -1,0 +1,68 @@
+package com.sats.dna.components.button
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun SatsButton(
+    onClick: () -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    colors: SatsButtonColor = SatsButtonColor.Primary,
+    isEnabled: Boolean = true,
+    isLoading: Boolean = false,
+    isLarge: Boolean = false,
+) {
+    val buttonColors = colors.toButtonColors()
+
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = isEnabled,
+        shape = SatsTheme.shapes.roundedCorners.small,
+        colors = buttonColors,
+        contentPadding = buttonPadding(isLarge),
+    ) {
+        if (isLoading) {
+            val color by buttonColors.contentColor(isEnabled)
+
+            CircularProgressIndicator(Modifier.size(24.dp), color, 1.5.dp)
+        } else {
+            Text(
+                text = label,
+                modifier = Modifier
+                    .height(24.dp)
+                    .wrapContentHeight(),
+            )
+        }
+    }
+}
+
+enum class SatsButtonColor { Primary }
+
+@Composable
+private fun SatsButtonColor.toButtonColors() = when (this) {
+    SatsButtonColor.Primary -> ButtonDefaults.buttonColors(
+        backgroundColor = SatsTheme.colors.primary.default,
+        contentColor = SatsTheme.colors.onPrimary.default,
+        disabledBackgroundColor = SatsTheme.colors.primary.disabled,
+        disabledContentColor = SatsTheme.colors.onPrimary.disabled,
+    )
+}
+
+@Composable
+private fun buttonPadding(isLarge: Boolean) = PaddingValues(
+    horizontal = SatsTheme.spacing.m,
+    vertical = if (isLarge) SatsTheme.spacing.m else SatsTheme.spacing.xs,
+)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -49,7 +49,7 @@ fun SatsButton(
     }
 }
 
-enum class SatsButtonColor { Primary, Cta }
+enum class SatsButtonColor { Primary, Cta, Secondary }
 
 @Composable
 private fun SatsButtonColor.toButtonColors() = when (this) {
@@ -65,6 +65,13 @@ private fun SatsButtonColor.toButtonColors() = when (this) {
         contentColor = SatsTheme.colors.onCta.default,
         disabledBackgroundColor = SatsTheme.colors.cta.disabled,
         disabledContentColor = SatsTheme.colors.onCta.disabled,
+    )
+
+    SatsButtonColor.Secondary -> ButtonDefaults.buttonColors(
+        backgroundColor = SatsTheme.colors.secondary.default,
+        contentColor = SatsTheme.colors.onSecondary.default,
+        disabledBackgroundColor = SatsTheme.colors.secondary.disabled,
+        disabledContentColor = SatsTheme.colors.onSecondary.disabled,
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -49,7 +49,7 @@ fun SatsButton(
     }
 }
 
-enum class SatsButtonColor { Primary }
+enum class SatsButtonColor { Primary, Cta }
 
 @Composable
 private fun SatsButtonColor.toButtonColors() = when (this) {
@@ -58,6 +58,13 @@ private fun SatsButtonColor.toButtonColors() = when (this) {
         contentColor = SatsTheme.colors.onPrimary.default,
         disabledBackgroundColor = SatsTheme.colors.primary.disabled,
         disabledContentColor = SatsTheme.colors.onPrimary.disabled,
+    )
+
+    SatsButtonColor.Cta -> ButtonDefaults.buttonColors(
+        backgroundColor = SatsTheme.colors.cta.default,
+        contentColor = SatsTheme.colors.onCta.default,
+        disabledBackgroundColor = SatsTheme.colors.cta.disabled,
+        disabledContentColor = SatsTheme.colors.onCta.disabled,
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -1,8 +1,11 @@
 package com.sats.dna.components.button
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -10,6 +13,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
@@ -34,17 +38,30 @@ fun SatsButton(
         colors = buttonColors,
         contentPadding = buttonPadding(isLarge),
     ) {
-        if (isLoading) {
-            val color by buttonColors.contentColor(isEnabled)
+        Box(
+            Modifier
+                .height(24.dp)
+                .animateContentSize(),
+            contentAlignment = Center,
+        ) {
+            if (isLoading) {
+                val color by buttonColors.contentColor(isEnabled)
 
-            CircularProgressIndicator(Modifier.size(24.dp), color, 1.5.dp)
-        } else {
-            Text(
-                text = label,
-                modifier = Modifier
-                    .height(24.dp)
-                    .wrapContentHeight(),
-            )
+                CircularProgressIndicator(
+                    Modifier
+                        .fillMaxHeight()
+                        .aspectRatio(1f),
+                    color = color,
+                    strokeWidth = 1.5.dp,
+                )
+            } else {
+                Text(
+                    text = label,
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .wrapContentHeight(),
+                )
+            }
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/CleanButtonPreviews.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/CleanButtonPreviews.kt
@@ -1,0 +1,131 @@
+package com.sats.dna.components.button.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isLoading = true,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isLoading = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isLoading = true,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Clean,
+            isLoading = true,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+private fun PreviewContainer(content: @Composable () -> Unit) {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.secondary) {
+            Box(Modifier.padding(SatsTheme.spacing.s), Center) {
+                content()
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/CtaButtonPreviews.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/CtaButtonPreviews.kt
@@ -1,0 +1,131 @@
+package com.sats.dna.components.button.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isLoading = true,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isLoading = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isLoading = true,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Cta,
+            isLoading = true,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+private fun PreviewContainer(content: @Composable () -> Unit) {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.secondary) {
+            Box(Modifier.padding(SatsTheme.spacing.s), Center) {
+                content()
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/PrimaryButtonPreviews.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/PrimaryButtonPreviews.kt
@@ -1,0 +1,131 @@
+package com.sats.dna.components.button.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isLoading = true,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isLoading = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isLoading = true,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Primary,
+            isLoading = true,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+private fun PreviewContainer(content: @Composable () -> Unit) {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.secondary) {
+            Box(Modifier.padding(SatsTheme.spacing.s), Center) {
+                content()
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/SecondaryButtonPreviews.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/SecondaryButtonPreviews.kt
@@ -1,0 +1,131 @@
+package com.sats.dna.components.button.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isLoading = true,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isLoading = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isLoading = true,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.Secondary,
+            isLoading = true,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+private fun PreviewContainer(content: @Composable () -> Unit) {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.secondary) {
+            Box(Modifier.padding(SatsTheme.spacing.s), Center) {
+                content()
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/WaitingListButtonPreviews.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/previews/WaitingListButtonPreviews.kt
@@ -1,0 +1,131 @@
+package com.sats.dna.components.button.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LabelOnlyLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isLoading = true,
+            isEnabled = false,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isLoading = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeDisabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isLoading = true,
+            isEnabled = false,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun LoadingLargeEnabledPreview() {
+    PreviewContainer {
+        SatsButton(
+            onClick = {},
+            label = "Button",
+            colors = SatsButtonColor.WaitingList,
+            isLoading = true,
+            isLarge = true,
+        )
+    }
+}
+
+@Composable
+private fun PreviewContainer(content: @Composable () -> Unit) {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.secondary) {
+            Box(Modifier.padding(SatsTheme.spacing.s), Center) {
+                content()
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/shapes/SatsShapes.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/shapes/SatsShapes.kt
@@ -25,10 +25,19 @@ object SatsShapes {
     val roundedCorners = RoundedCorners
 
     object RoundedCorners {
+        /** Rounded corners with 4 dp radius. */
         val extraSmall = RoundedCornerShape(4.dp)
+
+        /** Rounded corners with 8 dp radius. */
         val small = RoundedCornerShape(8.dp)
+
+        /** Rounded corners with 12 dp radius. */
         val medium = RoundedCornerShape(12.dp)
+
+        /** Rounded corners with 24 dp radius. */
         val large = RoundedCornerShape(24.dp)
+
+        /** Circular shape */
         val circle = CircleShape
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/spacing/SatsSpacing.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/spacing/SatsSpacing.kt
@@ -3,11 +3,24 @@ package com.sats.dna.spacing
 import androidx.compose.ui.unit.dp
 
 object SatsSpacing {
+    /** A spacing of 4 dp. */
     val xxs = 4.dp
+
+    /** A spacing of 8 dp. */
     val xs = 8.dp
+
+    /** A spacing of 12 dp. */
     val s = 12.dp
+
+    /** A spacing of 16 dp. */
     val m = 16.dp
+
+    /** A spacing of 24 dp. */
     val l = 24.dp
+
+    /** A spacing of 32 dp. */
     val xl = 32.dp
+
+    /** A spacing of 64 dp. */
     val xxl = 64.dp
 }


### PR DESCRIPTION
Create new `SatsButton` component. A button has a required `onClick` and `label` parameter, and some other optional parameters that further customize its looks. These parameters control

- if button is in a loading state,
- if it's enabled, and
- if it's of the large variant.

Icons are not supported at this time, but adding them shouldn't be too difficult.

**Some screenshots from the Sample App:**

|   |   |
| - | - |
| ![image](https://user-images.githubusercontent.com/386122/226965845-831a9f40-82b3-4fc5-9a57-d82912826b29.png) | ![image](https://user-images.githubusercontent.com/386122/226965874-8bce0603-dcff-49ea-b77f-7f0623c8d082.png) |

It's worth noting that there's [an ongoing discussion about the Clean Disabled style](https://www.figma.com/file/Nu1V7557V7KovgpZCNDObQ?node-id=3:1183#399889135), as it's illegible right now on the a Background Primary (and other dark backgrounds). 