### PR TITLE
NMA-4952: Pass service-account JSON to upload action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,10 @@ jobs:
         run: rm $GITHUB_WORKSPACE/play-upload.keystore
 
       - name: Upload Bundle to Play Store
-        uses: sindrenm/upload-google-play@v1.3.1
+        uses: r0adkill/upload-google-play@v1.1.1
         with:
           releaseFiles: ./sample-app/build/outputs/bundle/release/sample-app-release.aab
+          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.sats.dna.sample
           track: internal
           inAppUpdatePriority: 5


### PR DESCRIPTION
I've added the SERVICE_ACCOUNT_JSON secret to the repo (found in the key vault).