### PR TITLE
NMA-5030: Add control panel to sample app icons screen

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/icons/IconsScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/icons/IconsScreen.kt
@@ -1,23 +1,39 @@
 package com.sats.dna.sample.icons
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FilterChip
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.insets.ui.Scaffold
 import com.google.accompanist.insets.ui.TopAppBar
@@ -26,6 +42,8 @@ import com.sats.dna.theme.SatsTheme
 
 @Composable
 internal fun IconsScreen(navigateUp: () -> Unit) {
+    val controlPanelState = remember { ControlPanelState() }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -39,7 +57,7 @@ internal fun IconsScreen(navigateUp: () -> Unit) {
                 title = { Text("Icons") },
             )
         },
-        bottomBar = { Box(Modifier.navigationBarsPadding()) },
+        bottomBar = { ControlPanel(controlPanelState) },
         contentPadding = PaddingValues(SatsTheme.spacing.m),
     ) { innerPadding ->
         val icons = SatsTheme.icons.toIconDataList()
@@ -50,7 +68,50 @@ internal fun IconsScreen(navigateUp: () -> Unit) {
             contentPadding = innerPadding,
         ) {
             items(icons) { icon ->
-                IconCell(icon)
+                IconCell(
+                    icon = icon,
+                    showBorder = controlPanelState.showIconBorders,
+                    showLargeIcons = controlPanelState.showLargeIcons,
+                )
+            }
+        }
+    }
+}
+
+@Stable
+private class ControlPanelState {
+    var showIconBorders: Boolean by mutableStateOf(false)
+        private set
+
+    var showLargeIcons: Boolean by mutableStateOf(false)
+        private set
+
+    fun toggleIconBorders() {
+        showIconBorders = !showIconBorders
+    }
+
+    fun toggleLargeIcons() {
+        showLargeIcons = !showLargeIcons
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun ControlPanel(state: ControlPanelState) {
+    Surface(Modifier.fillMaxWidth(), elevation = 2.dp) {
+        Row(
+            Modifier
+                .navigationBarsPadding()
+                .padding(SatsTheme.spacing.m),
+            Arrangement.spacedBy(SatsTheme.spacing.m),
+            Alignment.CenterVertically,
+        ) {
+            FilterChip(state.showIconBorders, state::toggleIconBorders) {
+                Text("Show borders")
+            }
+
+            FilterChip(state.showLargeIcons, state::toggleLargeIcons) {
+                Text("Show large icons")
             }
         }
     }
@@ -133,9 +194,21 @@ private fun SatsIcons.toIconDataList() = listOf(
 )
 
 @Composable
-private fun IconCell(icon: IconData) {
-    Box(Modifier.size(iconCellSize), contentAlignment = Alignment.Center) {
-        Icon(icon.painter, contentDescription = null, Modifier.size(24.dp))
+private fun IconCell(icon: IconData, showBorder: Boolean, showLargeIcons: Boolean) {
+    val borderColor = if (showBorder) LocalContentColor.current else Color.Transparent
+    val size = if (showLargeIcons) 48.dp else 24.dp
+
+    Box(
+        Modifier.size(iconCellSize),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            icon.painter,
+            contentDescription = null,
+            Modifier
+                .size(size)
+                .border(Dp.Hairline, borderColor),
+        )
     }
 }
 


### PR DESCRIPTION
The control panel allows showing borders around the icons, which makes it easier to see what part of the icon is just padding.

The control panel also lets you control whether to view the icons in their default size (24 × 24 px), or in a larger 48 × 48 px.

| | |
|-|-|
| ![image](https://user-images.githubusercontent.com/386122/232525364-f02449f6-a057-437c-95c9-66253a2dafd8.png) | ![image](https://user-images.githubusercontent.com/386122/232525377-7a822d65-d9fc-49ee-b33b-b9097864b9e7.png) |
| ![image](https://user-images.githubusercontent.com/386122/232525521-1654209a-3529-456e-a8eb-7f96ed11f8ac.png) | ![image](https://user-images.githubusercontent.com/386122/232525534-853aa4d3-095e-41a1-a52a-9bdb4081f2b0.png) |
