### PR TITLE
NMA-5031: Publish only library in publish-local script

### DIFF
--- a/scripts/publish-local
+++ b/scripts/publish-local
@@ -19,4 +19,4 @@ fi
 log "Building & publishing version $version"
 
 cd "$(dirname "$0")/.." # make sure we're executing from the project directory
-VERSION_NAME=$version ./gradlew build publishToMavenLocal
+VERSION_NAME=$version ./gradlew :sats-dna:build :sats-dna:publishToMavenLocal


### PR DESCRIPTION
This greatly improves the speed of the script, as it doesn't need to build the sample app, and also doesn't need to do any minification.