### PR TITLE
NMA-5377: Introduce new SatsSnackbar component

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -13,6 +13,7 @@ import com.sats.dna.sample.components.CheckboxScreen
 import com.sats.dna.sample.components.CircularProgressIndicatorScreen
 import com.sats.dna.sample.components.RadioButtonsScreen
 import com.sats.dna.sample.components.SatsTextFieldScreen
+import com.sats.dna.sample.components.SnackbarScreen
 import com.sats.dna.sample.components.SurfaceScreen
 import com.sats.dna.sample.components.SwitchScreen
 import com.sats.dna.sample.components.appbar.SatsTopAppBarScreen
@@ -47,6 +48,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         circularProgressIndicatorScreen(navController::navigateUp)
         surfaceScreen(navController::navigateUp)
         textFieldScreen(navController::navigateUp)
+        snackbarScreen(navController::navigateUp)
     }
 }
 
@@ -152,6 +154,12 @@ private fun NavGraphBuilder.textFieldScreen(navigateUp: () -> Unit) {
     }
 }
 
+private fun NavGraphBuilder.snackbarScreen(navigateUp: () -> Unit) {
+    composable("/components/snackbar") {
+        SnackbarScreen(navigateUp)
+    }
+}
+
 internal fun NavController.navigateToColors() {
     navigate("/colors")
 }
@@ -214,4 +222,8 @@ internal fun NavController.navigateSurface() {
 
 internal fun NavController.navigateToTextField() {
     navigate("/components/text-field")
+}
+
+internal fun NavController.navigateToSnackbar() {
+    navigate("/components/snackbar")
 }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/SnackbarScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/SnackbarScreen.kt
@@ -1,0 +1,41 @@
+package com.sats.dna.sample.components
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import com.sats.dna.components.SatsSnackbar
+import com.sats.dna.components.SatsSnackbarAction
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+internal fun SnackbarScreen(navigateUp: () -> Unit) {
+    ComponentScreen("Snackbar", navigateUp) { innerPadding ->
+        Column(
+            Modifier
+                .padding(innerPadding)
+                .padding(SatsTheme.spacing.m)
+                .fillMaxSize()
+                .wrapContentSize(),
+            spacedBy(SatsTheme.spacing.m, CenterVertically),
+        ) {
+            val action = SatsSnackbarAction(action = {}, "Try again")
+
+            SatsSnackbar("That didn't work!", action = null)
+
+            SatsSnackbar("Oops, that didn't work at all! You should probably talk to the manager.", action = null)
+
+            SatsSnackbar("Oops, that didn't work at all! You should probably talk to the manager.", action)
+
+            SatsSnackbar(
+                "Oops, that didn't work at all! And this message is way too long for the entire text to be seen. " +
+                    "We might want to reconsider those texts.",
+                action,
+            )
+        }
+    }
+}

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import com.sats.dna.sample.navigateToIcons
 import com.sats.dna.sample.navigateToProgressBars
 import com.sats.dna.sample.navigateToRadioButtons
 import com.sats.dna.sample.navigateToSchedule
+import com.sats.dna.sample.navigateToSnackbar
 import com.sats.dna.sample.navigateToSwitch
 import com.sats.dna.sample.navigateToTextField
 import com.sats.dna.sample.navigateToTopAppBarScreen
@@ -136,6 +137,11 @@ internal fun HomeScreen(navController: NavController) {
             ListItem(
                 modifier = Modifier.clickable { navController.navigateToTextField() },
                 text = { Text("Text Field") },
+            )
+
+            ListItem(
+                modifier = Modifier.clickable { navController.navigateToSnackbar() },
+                text = { Text("Snackbar") },
             )
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSnackbar.kt
@@ -1,0 +1,54 @@
+package com.sats.dna.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
+import androidx.compose.ui.unit.dp
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+fun SatsSnackbar(message: String, action: SatsSnackbarAction?, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = SatsTheme.shapes.roundedCorners.small,
+        elevation = 6.dp,
+        color = SatsTheme.colors.surface.primary,
+        contentColor = SatsTheme.colors.onSurface.primary,
+    ) {
+        Row(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.s), CenterVertically) {
+            Icon(SatsTheme.icons.info, contentDescription = null)
+
+            Text(message, Modifier.weight(1f), maxLines = 3, overflow = Ellipsis)
+
+            if (action != null) {
+                SatsButton(action.action, action.label, colors = SatsButtonColor.Transparent)
+            }
+        }
+    }
+}
+
+class SatsSnackbarAction(val action: () -> Unit, val label: String)
+
+@LightDarkPreview
+@Composable
+private fun Preview() {
+    SatsTheme {
+        Surface {
+            val message = "Something went wrong. You should probably try that one more time."
+            val action = SatsSnackbarAction(action = {}, "Try again")
+
+            SatsSnackbar(message, action, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.insets.ui.Scaffold
+import com.sats.dna.components.SatsSnackbar
+import com.sats.dna.components.SatsSnackbarAction
 
 @Composable
 fun SatsScreen(
@@ -16,7 +18,7 @@ fun SatsScreen(
     scaffoldState: ScaffoldState = rememberScaffoldState(),
     topBar: @Composable () -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
-    snackbarHost: @Composable (SnackbarHostState) -> Unit = { SnackbarHost(it) },
+    snackbarHost: @Composable (SnackbarHostState) -> Unit = { SatsSnackbarHost(it) },
     floatingActionButton: @Composable () -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable (contentPadding: PaddingValues) -> Unit,
@@ -31,4 +33,15 @@ fun SatsScreen(
         contentPadding = contentPadding,
         content = content,
     )
+}
+
+@Composable
+private fun SatsSnackbarHost(snackbarHostState: SnackbarHostState) {
+    SnackbarHost(snackbarHostState) { snackbarData ->
+        val action = snackbarData.actionLabel?.let { label ->
+            SatsSnackbarAction(snackbarData::performAction, label)
+        }
+
+        SatsSnackbar(snackbarData.message, action)
+    }
 }


### PR DESCRIPTION
A drop-in replacement for the default Material snackbar, following [the Figma designs](https://www.figma.com/file/Nu1V7557V7KovgpZCNDObQ/sats-app-components-new-(wip)?type=design&node-id=1698-12618&mode=dev).

# Design

![image](https://github.com/sats-group/sats-dna-android/assets/386122/e1b04d34-4044-4a1f-8531-20e5a333f146)

# Implementation

| | |
|-|-|
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/e9678990-e471-4dfc-abb1-5dcefddda174) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/e651ae1f-a0c9-40f1-8df6-7cb88d1e8cdc) |

The main difference is probably that we're using a transparent `SatsButton` for the action, and that has an `action` color. I think that kind of makes sense, though, but feedback's more than welcome. This implementation also doesn't support a title, mostly because we never really have a title available to us. iOS shows titles such as “400 Bad Request”, but I think throwing HTTP status codes in our users' faces makes sense.

Finally, here's how it would look in the app

https://github.com/sats-group/sats-dna-android/assets/386122/b9aaf493-3c48-4e0b-96a5-f1688504ebc7

I've made `SatsScreen` default to showing this new component instead of regular snackbars, with the option to override with something else, should that be desirable. This mirrors how Material's `Scaffold` works.