### PR TITLE
Replace accompanist navigation with jetpack compose navigation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
-accompanist = "0.30.1"
+accompanist = "0.31.5-beta"
 agp = "8.0.2"
+jetpack-compose = "1.5.0-beta03"
+jetpack-navigation = "2.7.0-beta02"
 compose-compiler = "1.4.7"
 kotlin = "1.8.21"
 
@@ -12,19 +14,19 @@ kotlinter = { id = "org.jmailen.kotlinter", version = "3.15.0" }
 
 [libraries]
 accompanist-insetsUi = { module = "com.google.accompanist:accompanist-insets-ui", version.ref = "accompanist" }
-accompanist-navigation-animation = { module = "com.google.accompanist:accompanist-navigation-animation", version.ref = "accompanist" }
 accompanist-systemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 androidx-activity-compose = "androidx.activity:activity-compose:1.7.2"
 androidx-compose-bom = "androidx.compose:compose-bom:2023.06.01"
+androidx-compose-animation = { module = "androidx.compose.animation:animation", version.ref = "jetpack-compose" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
-androidx-compose-material = { module = "androidx.compose.material:material" }
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "jetpack-compose" }
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "jetpack-compose" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "jetpack-compose" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "jetpack-compose" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-core = "androidx.core:core-ktx:1.10.1"
-androidx-navigation-compose = "androidx.navigation:navigation-compose:2.6.0"
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "jetpack-navigation" }
 androidx-test-espresso = "androidx.test.espresso:espresso-core:3.5.1"
 androidx-test-junit = "androidx.test.ext:junit:1.1.5"
 google-material = "com.google.android.material:material:1.9.0"

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.sats.dna.sample"
-    compileSdk = 33
+    compileSdk = 34
 
     buildFeatures {
         compose = true
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdk = 23
-        targetSdk = 33
+        targetSdk = 34
 
         versionCode = System.getenv("VERSION_CODE")?.toIntOrNull()
         versionName = System.getenv("VERSION_NAME")
@@ -75,7 +75,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
     implementation(libs.accompanist.insetsUi)
-    implementation(libs.accompanist.navigation.animation)
     implementation(libs.accompanist.systemUiController)
     implementation(libs.accompanist.systemUiController)
     implementation(libs.androidx.activity.compose)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainActivity.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainActivity.kt
@@ -1,15 +1,12 @@
-@file:OptIn(ExperimentalAnimationApi::class)
-
 package com.sats.dna.sample
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.animation.AnimatedContentScope.SlideDirection
-import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.core.view.WindowCompat
-import com.google.accompanist.navigation.animation.AnimatedNavHost
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
 import com.sats.dna.theme.SatsTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,15 +17,15 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             SatsTheme {
-                val navController = rememberAnimatedNavController()
+                val navController = rememberNavController()
 
-                AnimatedNavHost(
+                NavHost(
                     navController = navController,
                     startDestination = MainRoute,
-                    enterTransition = { slideIntoContainer(SlideDirection.Left) },
-                    exitTransition = { slideOutOfContainer(SlideDirection.Left) },
-                    popEnterTransition = { slideIntoContainer(SlideDirection.Right) },
-                    popExitTransition = { slideOutOfContainer(SlideDirection.Right) },
+                    enterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left) },
+                    exitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Left) },
+                    popEnterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Right) },
+                    popExitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right) },
                 ) {
                     mainGraph(navController)
                 }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -1,12 +1,9 @@
-@file:OptIn(ExperimentalAnimationApi::class)
-
 package com.sats.dna.sample
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.navigation
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import com.sats.dna.sample.colors.ColorsScreen
 import com.sats.dna.sample.components.ButtonsScreen
 import com.sats.dna.sample.components.CheckboxScreen

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -1,7 +1,6 @@
 package com.sats.dna.components.button
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -26,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun SatsButton(
     onClick: () -> Unit,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
@@ -1,7 +1,6 @@
 package com.sats.dna.components.button
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
@@ -24,7 +23,6 @@ import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
-@OptIn(ExperimentalAnimationApi::class)
 fun SatsIconButton(
     onClick: () -> Unit,
     icon: Painter,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Sats DNA Android"
+rootProject.name = "sats-dna-android"
 
 include(":core-tooling")
 include(":sample-app")


### PR DESCRIPTION
Update compose to 1.5.0-beta03 and replace accompanist animated navigation with jetpack compose navigation that now has built in animations. Also updated accompanist to 0.31.5-beta that supports the new jetpack compose version.