### PR TITLE
NMA-5430: Convert sealed sub-objects to data objects

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -97,8 +97,8 @@ fun SatsButton(
 
 private sealed interface IconContent {
     data class Icon(val painter: Painter) : IconContent
-    object Loading : IconContent
-    object Empty : IconContent
+    data object Loading : IconContent
+    data object Empty : IconContent
 }
 
 @Composable


### PR DESCRIPTION
As data objects are now stable in Kotlin 1.9.0, it's recommended that all sealed sub-objects are declared as such. There's even a lint warning for this now with a quick-fix, which is what I've applied here.

https://kotlinlang.org/docs/whatsnew19.html#stable-data-objects-for-symmetry-with-data-classes