### PR TITLE
NMA-5637: Split release.yml into more jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,35 @@ on:
       - v*.*.*
 
 jobs:
-  build-and-release-lib:
-    name: Build and Release Library
+  run-tests:
+    name: Run Tests
     runs-on: buildjet-4vcpu-ubuntu-2204
-    timeout-minutes: 45
-    permissions:
-      contents: write
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 19
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 19
+
+      - name: Run tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test
+
+  build-lib:
+    name: Build Library
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    needs: run-tests
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: Set up JDK 19
         uses: actions/setup-java@v3
@@ -34,7 +53,7 @@ jobs:
       - name: Build library
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: :sats-dna:build
         env:
           SATS_KEYSTORE_FILE: ${{ github.workspace }}/play-upload.keystore
           SATS_KEYSTORE_PASSWORD: ${{ secrets.PLAY_UPLOAD_KEYSTORE_PASSWORD }}
@@ -44,33 +63,53 @@ jobs:
       - name: Remove Decoded Keystore File
         run: rm $GITHUB_WORKSPACE/play-upload.keystore
 
-      - name: Run tests
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: sats-dna-lib
+          path: sats-dna/build/outputs/aar/sats-dna-release.aar
+          if-no-files-found: error
+
+  release-lib:
+    name: Release Library
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    needs: build-lib
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: sats-dna-lib
+          path: sats-dna/build/outputs/aar/sats-dna-release.aar
+
+      - name: Publish to GitHub Packages
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :sats-dna:test
+          arguments: :sats-dna:publishReleasePublicationToGitHubPackagesRepository
+        env:
+          GH_PACKAGES_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME }}
+          GH_PACKAGES_PASSWORD: ${{ secrets.GH_PACKAGES_PASSWORD }}
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true
+          artifacts: sats-dna/build/outputs/aar/sats-dna-release.aar
+          artifactErrorsFailBuild: true
           makeLatest: true
 
-      - name: Publish Artifacts
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish
-        env:
-          GH_PACKAGES_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME }}
-          GH_PACKAGES_PASSWORD: ${{ secrets.GH_PACKAGES_PASSWORD }}
-
-  build-and-release-sample-app:
-    name: Build and Release Sample App
+  build-sample-app:
+    name: Build DNA Sample App
+    needs: run-tests
     runs-on: buildjet-4vcpu-ubuntu-2204
-    timeout-minutes: 45
+    timeout-minutes: 5
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
 
       - name: Set up JDK 19
         uses: actions/setup-java@v3
@@ -84,17 +123,12 @@ jobs:
       - name: Generate Version Name
         run: echo "VERSION_NAME=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_ENV
 
-      - name: Run Sample App unit tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :sample-app:test
-
       - name: Decode Keystore File
         run: echo $KEYSTORE_FILE_BASE64 | base64 --decode - > $GITHUB_WORKSPACE/play-upload.keystore
         env:
           KEYSTORE_FILE_BASE64: ${{ secrets.PLAY_UPLOAD_KEYSTORE_FILE_BASE64 }}
 
-      - name: Bundle Sample App
+      - name: Generate App Bundle
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :sample-app:bundleRelease
@@ -106,6 +140,25 @@ jobs:
 
       - name: Remove Decoded Keystore File
         run: rm $GITHUB_WORKSPACE/play-upload.keystore
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: sats-dna-lib
+          path: sample-app/build/outputs/bundle/release/sample-app-release.aab
+          if-no-files-found: error
+
+  release-sample-app:
+    name: Release DNA Sample App
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    timeout-minutes: 5
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: sats-dna-lib
+          path: sample-app/build/outputs/bundle/release/sample-app-release.aab
 
       - name: Upload Bundle to Play Store
         uses: r0adkll/upload-google-play@v1.1.2


### PR DESCRIPTION
Specifically, split up building artifacts and releasing them. This will
allow us to monitor them individually, and also retry release jobs if
they fail, without having to rebuild.