### PR TITLE
NMA-5688: Remove text property from SatsRewardsLabel

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/LabelsScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/LabelsScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,7 +55,7 @@ internal fun LabelsScreen(navigateUp: () -> Unit) {
 
             Section("Rewards Labels") {
                 SatsRewardsLevel.entries.forEach { level ->
-                    SatsRewardsLabel("$level", level)
+                    SatsRewardsLabel(level)
                 }
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsLabel.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsLabel.kt
@@ -43,7 +43,6 @@ fun SatsLabel(
 
 @Composable
 fun SatsRewardsLabel(
-    text: String,
     level: SatsRewardsLevel,
     modifier: Modifier = Modifier,
 ) {
@@ -52,6 +51,13 @@ fun SatsRewardsLabel(
         SatsRewardsLevel.Silver -> SatsTheme.colors.rewards.silver
         SatsRewardsLevel.Gold -> SatsTheme.colors.rewards.gold
         SatsRewardsLevel.Platinum -> SatsTheme.colors.rewards.platinum
+    }
+
+    val text = when (level) {
+        SatsRewardsLevel.Blue -> "BLUE"
+        SatsRewardsLevel.Silver -> "SILVER"
+        SatsRewardsLevel.Gold -> "GOLD"
+        SatsRewardsLevel.Platinum -> "PLATINUM"
     }
 
     val contentColor = SatsTheme.colors.onRewards.primary
@@ -108,7 +114,7 @@ private fun SatsRewardsLabelPreview() {
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 SatsRewardsLevel.entries.forEach { level ->
-                    SatsRewardsLabel("$level", level = level)
+                    SatsRewardsLabel(level)
                 }
             }
         }


### PR DESCRIPTION
This should always show the untranslatable “blue”, “silver”, “gold” or
“platinum” texts, depending on which level it represents.
