### PR TITLE
NMA-5698: Make subtitle optional in Campaign Module

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/CampaignModulesScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/CampaignModulesScreen.kt
@@ -38,6 +38,13 @@ internal fun CampaignModulesScreen(navigateUp: () -> Unit) {
                 subtitle = "Today is a day to learn, grow, and challenge yourself.",
                 onClick = {},
             )
+
+            SatsCampaignModule(
+                imageUrl = "https://picsum.photos/id/30/1920/1080.webp",
+                title = "Happy Training Day",
+                subtitle = null,
+                onClick = {},
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
@@ -21,7 +21,7 @@ import com.sats.dna.tooling.PreviewImagePlaceholder
 fun SatsCampaignModule(
     imageUrl: String,
     title: String,
-    subtitle: String,
+    subtitle: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -35,7 +35,9 @@ fun SatsCampaignModule(
             ) {
                 Text(title, style = SatsTheme.typography.medium.basic)
 
-                Text(subtitle, style = SatsTheme.typography.default.small)
+                if (subtitle != null) {
+                    Text(subtitle, style = SatsTheme.typography.default.small)
+                }
             }
         }
     }
@@ -71,6 +73,19 @@ private fun SatsCampaignModulePreview() {
             subtitle = "Today is a day to learn, grow, and challenge yourself. " +
                 "It's a day to step outside of your comfort zone and try new things. " +
                 "It's a day to invest in yourself and your future.",
+            onClick = {},
+        )
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SatsCampaignWithoutSubtitleModulePreview() {
+    SatsTheme {
+        SatsCampaignModule(
+            imageUrl = "https://picsum.photos/1920/1080",
+            title = "Happy Training Day",
+            subtitle = null,
             onClick = {},
         )
     }


### PR DESCRIPTION
Apparently, they're not always there, as is the case for one of our new campaigns.

|Before|After|
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/a3442a33-5271-42f2-b7c2-bf6713594154)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/30d81309-27ca-436a-accf-c40206a5c7c3)|
