### PR TITLE
NMA-5749: Rename SatsLabel → SatsTag

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -17,7 +17,6 @@ import com.sats.dna.sample.screens.ColorsSampleScreen
 import com.sats.dna.sample.screens.CompletedWorkoutListItemSampleScreen
 import com.sats.dna.sample.screens.GeneralListItemSampleScreen
 import com.sats.dna.sample.screens.IconsSampleScreen
-import com.sats.dna.sample.screens.LabelsSampleScreen
 import com.sats.dna.sample.screens.PlaceholdersSampleScreen
 import com.sats.dna.sample.screens.ProgressBarsSampleScreen
 import com.sats.dna.sample.screens.RadioButtonsSampleScreen
@@ -25,6 +24,7 @@ import com.sats.dna.sample.screens.ScheduleSampleScreen
 import com.sats.dna.sample.screens.SnackbarSampleScreen
 import com.sats.dna.sample.screens.SurfaceSampleScreen
 import com.sats.dna.sample.screens.SwitchSampleScreen
+import com.sats.dna.sample.screens.TagsSampleScreen
 import com.sats.dna.sample.screens.TextFieldSampleScreen
 import com.sats.dna.sample.screens.TopBarSampleScreen
 import com.sats.dna.sample.screens.TrafficLightsSampleScreen
@@ -51,7 +51,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         CircularProgressIndicatorSampleScreen.navScreen(navController)
         CompletedWorkoutListItemSampleScreen.navScreen(navController)
         GeneralListItemSampleScreen.navScreen(navController)
-        LabelsSampleScreen.navScreen(navController)
+        TagsSampleScreen.navScreen(navController)
         PlaceholdersSampleScreen.navScreen(navController)
         ProgressBarsSampleScreen.navScreen(navController)
         RadioButtonsSampleScreen.navScreen(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/TagsScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/TagsScreen.kt
@@ -17,7 +17,7 @@ import com.sats.dna.components.SatsRewardsLevel
 import com.sats.dna.theme.SatsTheme
 
 @Composable
-internal fun LabelsScreen(navigateUp: () -> Unit) {
+internal fun TagsScreen(navigateUp: () -> Unit) {
     ComponentScreen("Labels", navigateUp) { innerPadding ->
         Column(
             Modifier
@@ -63,6 +63,6 @@ private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) 
 @Composable
 private fun Preview() {
     SatsTheme {
-        LabelsScreen(navigateUp = {})
+        TagsScreen(navigateUp = {})
     }
 }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
@@ -28,7 +28,6 @@ import com.sats.dna.sample.screens.ColorsSampleScreen
 import com.sats.dna.sample.screens.CompletedWorkoutListItemSampleScreen
 import com.sats.dna.sample.screens.GeneralListItemSampleScreen
 import com.sats.dna.sample.screens.IconsSampleScreen
-import com.sats.dna.sample.screens.LabelsSampleScreen
 import com.sats.dna.sample.screens.PlaceholdersSampleScreen
 import com.sats.dna.sample.screens.ProgressBarsSampleScreen
 import com.sats.dna.sample.screens.RadioButtonsSampleScreen
@@ -36,6 +35,7 @@ import com.sats.dna.sample.screens.ScheduleSampleScreen
 import com.sats.dna.sample.screens.SnackbarSampleScreen
 import com.sats.dna.sample.screens.SurfaceSampleScreen
 import com.sats.dna.sample.screens.SwitchSampleScreen
+import com.sats.dna.sample.screens.TagsSampleScreen
 import com.sats.dna.sample.screens.TextFieldSampleScreen
 import com.sats.dna.sample.screens.TopBarSampleScreen
 import com.sats.dna.sample.screens.TrafficLightsSampleScreen
@@ -76,7 +76,7 @@ internal fun HomeScreen(navController: NavController) {
             CircularProgressIndicatorSampleScreen.HomeListItem(navController)
             CompletedWorkoutListItemSampleScreen.HomeListItem(navController)
             GeneralListItemSampleScreen.HomeListItem(navController)
-            LabelsSampleScreen.HomeListItem(navController)
+            TagsSampleScreen.HomeListItem(navController)
             PlaceholdersSampleScreen.HomeListItem(navController)
             ProgressBarsSampleScreen.HomeListItem(navController)
             RadioButtonsSampleScreen.HomeListItem(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/LabelsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/LabelsSampleScreen.kt
@@ -1,9 +1,0 @@
-package com.sats.dna.sample.screens
-
-import com.sats.dna.sample.components.LabelsScreen
-
-data object LabelsSampleScreen : SampleScreen(
-    name = "Labels",
-    route = "/components/labels",
-    screen = { LabelsScreen(it::navigateUp) },
-)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
@@ -1,0 +1,9 @@
+package com.sats.dna.sample.screens
+
+import com.sats.dna.sample.components.TagsScreen
+
+data object TagsSampleScreen : SampleScreen(
+    name = "Tags",
+    route = "/components/tags",
+    screen = { TagsScreen(it::navigateUp) },
+)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
@@ -12,37 +12,46 @@ import androidx.compose.ui.graphics.Color
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
-enum class SatsLabelColor {
+@Composable
+fun SatsTag(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: SatsTagColor = SatsTagColor.Primary,
+) {
+    val backgroundColor = when (color) {
+        SatsTagColor.Primary -> SatsTheme.colors.primary.default
+        SatsTagColor.Secondary -> SatsTheme.colors.secondary.default
+        SatsTagColor.Cta -> SatsTheme.colors.cta.default
+    }
+
+    val contentColor = when (color) {
+        SatsTagColor.Primary -> SatsTheme.colors.onPrimary.default
+        SatsTagColor.Secondary -> SatsTheme.colors.onSecondary.default
+        SatsTagColor.Cta -> SatsTheme.colors.onCta.default
+    }
+
+    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+}
+
+enum class SatsTagColor {
     Primary, Secondary, Cta,
 }
 
-enum class SatsRewardsLevel {
-    Blue, Silver, Gold, Platinum,
-}
-
+@Deprecated("Renamed to SatsTag", ReplaceWith("SatsTag(text, modifier, color)"))
 @Composable
 fun SatsLabel(
     text: String,
     modifier: Modifier = Modifier,
     color: SatsLabelColor = SatsLabelColor.Primary,
 ) {
-    val backgroundColor = when (color) {
-        SatsLabelColor.Primary -> SatsTheme.colors.primary.default
-        SatsLabelColor.Secondary -> SatsTheme.colors.secondary.default
-        SatsLabelColor.Cta -> SatsTheme.colors.cta.default
-    }
-
-    val contentColor = when (color) {
-        SatsLabelColor.Primary -> SatsTheme.colors.onPrimary.default
-        SatsLabelColor.Secondary -> SatsTheme.colors.onSecondary.default
-        SatsLabelColor.Cta -> SatsTheme.colors.onCta.default
-    }
-
-    SatsLabelLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+    SatsTag(text, modifier, color)
 }
 
+@Deprecated("Renamed to SatsTagColor", ReplaceWith("SatsTagColor"))
+typealias SatsLabelColor = SatsTagColor
+
 @Composable
-fun SatsRewardsLabel(
+fun SatsRewardsTag(
     level: SatsRewardsLevel,
     modifier: Modifier = Modifier,
 ) {
@@ -62,11 +71,21 @@ fun SatsRewardsLabel(
 
     val contentColor = SatsTheme.colors.onRewards.default
 
-    SatsLabelLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+}
+
+@Deprecated("Renamed to SatsRewardsTag", ReplaceWith("SatsRewardsTag(level, modifier)"))
+@Composable
+fun SatsRewardsLabel(level: SatsRewardsLevel, modifier: Modifier = Modifier) {
+    SatsRewardsTag(level, modifier)
+}
+
+enum class SatsRewardsLevel {
+    Blue, Silver, Gold, Platinum,
 }
 
 @Composable
-private fun SatsLabelLayout(
+private fun SatsTagLayout(
     text: String,
     backgroundColor: Color,
     contentColor: Color,
@@ -87,7 +106,7 @@ private fun SatsLabelLayout(
 
 @LightDarkPreview
 @Composable
-private fun SatsLabelPreview() {
+private fun SatsTagPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors.background.primary) {
             Column(
@@ -95,8 +114,8 @@ private fun SatsLabelPreview() {
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                SatsLabelColor.entries.forEach { color ->
-                    SatsLabel("$color", color = color)
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color)
                 }
             }
         }
@@ -105,7 +124,7 @@ private fun SatsLabelPreview() {
 
 @LightDarkPreview
 @Composable
-private fun SatsRewardsLabelPreview() {
+private fun SatsRewardsTagPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors.background.primary) {
             Column(
@@ -114,7 +133,7 @@ private fun SatsRewardsLabelPreview() {
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 SatsRewardsLevel.entries.forEach { level ->
-                    SatsRewardsLabel(level)
+                    SatsRewardsTag(level)
                 }
             }
         }


### PR DESCRIPTION
This has been renamed in the design system, as iOS was unable to use the name “Label”. I've kept the old names for backwards compatibility reasons.

- Rename SatsLabel → SatsTag
- Rename SatsLabelColor → SatsTagColor
- Rename SatsRewardsLabel → SatsRewardsTag
