### PR TITLE
NMA-5733: Fix Campaign Module in dark mode

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale


### PR DESCRIPTION
This broke when introducing Material 3, as it uses SatsCard behind the scenes, which is not yet migrated over to Material 3.
