### PR TITLE
NMA-5755: Support Material 3 elevated cards in SatsCard

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/card/SatsCardScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/card/SatsCardScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,13 +24,14 @@ internal fun SatsCardScreen(navigateUp: () -> Unit) {
     ComponentScreen("Cards", navigateUp) { innerPadding ->
         Column(
             Modifier
+                .verticalScroll(rememberScrollState())
                 .fillMaxSize()
                 .padding(innerPadding)
                 .padding(SatsTheme.spacing.m),
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            SatsCard {
+            SatsCard(useMaterial3 = true) {
                 Column(Modifier.clickable { }) {
                     Box(
                         Modifier
@@ -40,7 +43,26 @@ internal fun SatsCardScreen(navigateUp: () -> Unit) {
                     }
 
                     Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Some title", style = SatsTheme.typography.medium.large)
+                        Text("Material 3 Card", style = SatsTheme.typography.medium.large)
+
+                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+                    }
+                }
+            }
+
+            SatsCard(useMaterial3 = false) {
+                Column(Modifier.clickable { }) {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9)
+                            .background(SatsTheme.colors.waitingList.primary),
+                    ) {
+                        Text("Image", Modifier.align(Alignment.Center), color = SatsTheme.colors.onWaitingList.primary)
+                    }
+
+                    Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
+                        Text("Material 2 Card", style = SatsTheme.typography.medium.large)
 
                         Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
                     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -25,7 +25,7 @@ fun SatsCampaignModule(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    SatsCard(modifier) {
+    SatsCard(modifier, useMaterial3 = true) {
         Column(Modifier.clickable { onClick() }) {
             HeroImage(imageUrl)
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -7,29 +7,73 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Card
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
+import androidx.compose.material.Card as M2Card
 
 @Composable
-fun SatsCard(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    Card(
-        modifier = modifier,
-        shape = SatsTheme.shapes.roundedCorners.small,
-        backgroundColor = SatsTheme.colors.surface.primary,
-        contentColor = SatsTheme.colors.onSurface.primary,
-        content = content,
-    )
+fun SatsCard(modifier: Modifier = Modifier, useMaterial3: Boolean = false, content: @Composable () -> Unit) {
+    if (useMaterial3) {
+        ElevatedCard(
+            modifier = modifier,
+            shape = SatsTheme.shapes.roundedCorners.small,
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = SatsTheme.colors.surface.primary,
+                contentColor = SatsTheme.colors.onSurface.primary,
+            ),
+            elevation = CardDefaults.elevatedCardElevation(1.dp),
+        ) {
+            content()
+        }
+    } else {
+        M2Card(
+            modifier = modifier,
+            shape = SatsTheme.shapes.roundedCorners.small,
+            backgroundColor = SatsTheme.colors.surface.primary,
+            contentColor = SatsTheme.colors.onSurface.primary,
+            content = content,
+        )
+    }
 }
 
 @LightDarkPreview
 @Composable
 private fun Preview() {
+    SatsTheme {
+        Surface(color = SatsTheme.colors.background.primary) {
+            SatsCard(Modifier.padding(SatsTheme.spacing.m), useMaterial3 = true) {
+                Column {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9)
+                            .background(SatsTheme.colors.waitingList.primary),
+                    ) {
+                        Text("Image", Modifier.align(Alignment.Center), color = SatsTheme.colors.onWaitingList.primary)
+                    }
+
+                    Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
+                        Text("Material 3", style = SatsTheme.typography.medium.large)
+
+                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun Material2Preview() {
     SatsTheme {
         Surface(color = SatsTheme.colors.background.primary) {
             SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
@@ -44,7 +88,7 @@ private fun Preview() {
                     }
 
                     Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Some title", style = SatsTheme.typography.medium.large)
+                        Text("Material 2", style = SatsTheme.typography.medium.large)
 
                         Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
                     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -20,7 +20,7 @@ fun Schedule(
     onWorkoutClicked: (workout: ScheduledWorkout) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    SatsCard(modifier.fillMaxWidth()) {
+    SatsCard(modifier.fillMaxWidth(), useMaterial3 = true) {
         val days = workouts.groupBy { it.day }
 
         ScheduledDays(days, onWorkoutClicked)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
@@ -2,7 +2,7 @@ package com.sats.dna.components.upcomingworkouts
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.sats.dna.components.SatsSurface

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
@@ -29,7 +29,7 @@ import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * A section for a day of upcoming workouts
-
+ *
  * @param day A formatted day that will be displayed as the title of the section.
  * @param content The list of the containing workouts for this day. Consider using [UpcomingWorkoutListItem].
  * @param modifier The modifier to apply to the section.


### PR DESCRIPTION
Add a `useMaterial3` flag to `SatsCard`, which will then proxy to an `ElevatedCard` instead of the old Material 2 `Card` component. Users of Material 3 cards must be careful to also use text and icon components from Material 3, so that styles are applied correctly.

Note that Material 3 elevated cards have a slightly different surface tint than Material 2's cards, causing a little bit of an inconsistency. See the images 

| | |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/2c7a2ad4-8c8f-4a98-9f1f-bd24d0bec4b5)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/f75fa048-f4da-4a6c-8232-10ca862e6c22)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/7ef8e9e4-7bc2-437d-9349-ed6fa098db2c)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/48a0459d-7021-4659-9b04-577d66563e08)|