### PR TITLE
NMA-5770: Introduce a BrandLogo component

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.sats.dna.sample.home.HomeScreen
 import com.sats.dna.sample.screens.BottomNavigationSampleScreen
+import com.sats.dna.sample.screens.BrandLogoSampleScreen
 import com.sats.dna.sample.screens.ButtonsSampleScreen
 import com.sats.dna.sample.screens.CampaignModuleSampleScreen
 import com.sats.dna.sample.screens.CardSampleScreen
@@ -42,6 +43,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         TypographySampleScreen.navScreen(navController)
 
         BottomNavigationSampleScreen.navScreen(navController)
+        BrandLogoSampleScreen.navScreen(navController)
         ButtonsSampleScreen.navScreen(navController)
         CampaignModuleSampleScreen.navScreen(navController)
         CardSampleScreen.navScreen(navController)
@@ -51,7 +53,6 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         CircularProgressIndicatorSampleScreen.navScreen(navController)
         CompletedWorkoutListItemSampleScreen.navScreen(navController)
         GeneralListItemSampleScreen.navScreen(navController)
-        TagsSampleScreen.navScreen(navController)
         PlaceholdersSampleScreen.navScreen(navController)
         ProgressBarsSampleScreen.navScreen(navController)
         RadioButtonsSampleScreen.navScreen(navController)
@@ -59,6 +60,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         SnackbarSampleScreen.navScreen(navController)
         SurfaceSampleScreen.navScreen(navController)
         SwitchSampleScreen.navScreen(navController)
+        TagsSampleScreen.navScreen(navController)
         TextFieldSampleScreen.navScreen(navController)
         TopBarSampleScreen.navScreen(navController)
         TrafficLightsSampleScreen.navScreen(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/BrandLogoScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/BrandLogoScreen.kt
@@ -1,0 +1,61 @@
+package com.sats.dna.sample.components
+
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.sats.dna.components.Brand
+import com.sats.dna.components.BrandLogo
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+internal fun BrandLogoScreen(navigateUp: () -> Unit) {
+    ComponentScreen("Brand Logo", navigateUp) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(vertical = SatsTheme.spacing.m),
+            verticalArrangement = spacedBy(SatsTheme.spacing.xl, CenterVertically),
+            horizontalAlignment = CenterHorizontally,
+        ) {
+            BrandLogo(
+                brand = Brand.Elixia,
+                contentDescription = null,
+            )
+
+            BrandLogo(
+                brand = Brand.Elixia,
+                contentDescription = null,
+                isFullName = true,
+            )
+
+            Divider()
+
+            BrandLogo(
+                brand = Brand.Sats,
+                contentDescription = null,
+            )
+
+            BrandLogo(
+                brand = Brand.Sats,
+                contentDescription = null,
+                isFullName = true,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BrandLogoScreenPreview() {
+    SatsTheme {
+        BrandLogoScreen(navigateUp = {})
+    }
+}

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.navigation.NavController
 import com.sats.dna.components.appbar.M3SatsTopAppBar
 import com.sats.dna.components.screen.SatsScreen
 import com.sats.dna.sample.screens.BottomNavigationSampleScreen
+import com.sats.dna.sample.screens.BrandLogoSampleScreen
 import com.sats.dna.sample.screens.ButtonsSampleScreen
 import com.sats.dna.sample.screens.CampaignModuleSampleScreen
 import com.sats.dna.sample.screens.CardSampleScreen
@@ -59,6 +60,7 @@ internal fun HomeScreen(navController: NavController) {
             Divider(Modifier.padding(vertical = SatsTheme.spacing.s))
 
             BottomNavigationSampleScreen.HomeListItem(navController)
+            BrandLogoSampleScreen.HomeListItem(navController)
             ButtonsSampleScreen.HomeListItem(navController)
             CampaignModuleSampleScreen.HomeListItem(navController)
             CardSampleScreen.HomeListItem(navController)
@@ -68,7 +70,6 @@ internal fun HomeScreen(navController: NavController) {
             CircularProgressIndicatorSampleScreen.HomeListItem(navController)
             CompletedWorkoutListItemSampleScreen.HomeListItem(navController)
             GeneralListItemSampleScreen.HomeListItem(navController)
-            TagsSampleScreen.HomeListItem(navController)
             PlaceholdersSampleScreen.HomeListItem(navController)
             ProgressBarsSampleScreen.HomeListItem(navController)
             RadioButtonsSampleScreen.HomeListItem(navController)
@@ -76,6 +77,7 @@ internal fun HomeScreen(navController: NavController) {
             SnackbarSampleScreen.HomeListItem(navController)
             SurfaceSampleScreen.HomeListItem(navController)
             SwitchSampleScreen.HomeListItem(navController)
+            TagsSampleScreen.HomeListItem(navController)
             TextFieldSampleScreen.HomeListItem(navController)
             TopBarSampleScreen.HomeListItem(navController)
             TrafficLightsSampleScreen.HomeListItem(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BrandLogoSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BrandLogoSampleScreen.kt
@@ -1,0 +1,9 @@
+package com.sats.dna.sample.screens
+
+import com.sats.dna.sample.components.BrandLogoScreen
+
+data object BrandLogoSampleScreen : SampleScreen(
+    name = "Brand Logo",
+    route = "/components/brand-logo",
+    screen = { BrandLogoScreen(it::navigateUp) },
+)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
@@ -1,0 +1,107 @@
+package com.sats.dna.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import com.sats.dna.R
+import com.sats.dna.internal.MaterialIcon
+import com.sats.dna.internal.materialIconTint
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
+
+@Composable
+fun BrandLogo(
+    brand: Brand,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    isFullName: Boolean = false,
+    useMaterial3: Boolean = false,
+    tint: Color = materialIconTint(useMaterial3),
+) {
+    val painter = if (isFullName) brand.fullNameIconPainter() else brand.letterIconPainter()
+
+    MaterialIcon(
+        useMaterial3 = useMaterial3,
+        painter = painter,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+enum class Brand {
+    Sats,
+    Elixia,
+}
+
+@Composable
+private fun Brand.letterIconPainter() = when (this) {
+    Brand.Sats -> painterResource(R.drawable.ic_letter_s)
+    Brand.Elixia -> painterResource(R.drawable.ic_letter_e)
+}
+
+@Composable
+private fun Brand.fullNameIconPainter() = when (this) {
+    Brand.Sats -> painterResource(R.drawable.ic_sats)
+    Brand.Elixia -> painterResource(R.drawable.ic_elixia)
+}
+
+@LightDarkPreview
+@Composable
+private fun ElixiaLetterPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            BrandLogo(
+                brand = Brand.Elixia,
+                contentDescription = null,
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun ElixiaFullPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            BrandLogo(
+                brand = Brand.Elixia,
+                contentDescription = null,
+                isFullName = true,
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SatsLetterPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            BrandLogo(
+                brand = Brand.Sats,
+                contentDescription = null,
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SatsFullPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            BrandLogo(
+                brand = Brand.Sats,
+                contentDescription = null,
+                isFullName = true,
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
@@ -16,15 +16,20 @@ internal fun MaterialIcon(
     painter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = if (useMaterial3) {
-        Material2LocalContentColor.current.copy(alpha = Material2LocalContentAlpha.current)
-    } else {
-        Material3LocalContentColor.current
-    },
+    tint: Color = materialIconTint(useMaterial3),
 ) {
     if (useMaterial3) {
         Material2Icon(painter, contentDescription, modifier, tint)
     } else {
         Material3Icon(painter, contentDescription, modifier, tint)
+    }
+}
+
+@Composable
+internal fun materialIconTint(useMaterial3: Boolean): Color {
+    return if (useMaterial3) {
+        Material2LocalContentColor.current.copy(alpha = Material2LocalContentAlpha.current)
+    } else {
+        Material3LocalContentColor.current
     }
 }


### PR DESCRIPTION
A new component that, given a brand (`Sats` or `Elixia`) paints the correct logo.

| | |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/84b844bc-e77d-4668-8d6d-c98c2e8855ae)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/14f62bd3-da17-4484-9770-8e251440b263)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/034aab58-cdca-4ec8-90ac-c569f1c8e820)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/44622256-0448-43d3-8af3-31c9b372ba40)

| | |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/edae7c47-8e26-4a20-bb04-51407e469d07)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/ebc0d233-073e-452f-982e-35890a54d1a3)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/12b85ab6-2185-4292-a481-43f958cc0589)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/7e88c00e-fd5b-4434-991a-b55e6d99d802)|
