### PR TITLE
NMA-5787: Put Material 3 usage in a CompositionLocal

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/components/card/SatsCardScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/components/card/SatsCardScreen.kt
@@ -31,7 +31,7 @@ internal fun SatsCardScreen(navigateUp: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            SatsCard(useMaterial3 = true) {
+            SatsCard {
                 Column(Modifier.clickable { }) {
                     Box(
                         Modifier
@@ -44,25 +44,6 @@ internal fun SatsCardScreen(navigateUp: () -> Unit) {
 
                     Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
                         Text("Material 3 Card", style = SatsTheme.typography.medium.large)
-
-                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
-                    }
-                }
-            }
-
-            SatsCard(useMaterial3 = false) {
-                Column(Modifier.clickable { }) {
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9)
-                            .background(SatsTheme.colors.waitingList.primary),
-                    ) {
-                        Text("Image", Modifier.align(Alignment.Center), color = SatsTheme.colors.onWaitingList.primary)
-                    }
-
-                    Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Material 2 Card", style = SatsTheme.typography.medium.large)
 
                         Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
                     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
@@ -17,7 +17,7 @@ fun BrandLogo(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     isFullName: Boolean = false,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
     tint: Color = materialIconTint(useMaterial3),
 ) {
     val painter = if (isFullName) brand.fullNameIconPainter() else brand.letterIconPainter()

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
@@ -17,13 +17,11 @@ fun BrandLogo(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     isFullName: Boolean = false,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
-    tint: Color = materialIconTint(useMaterial3),
+    tint: Color = materialIconTint(),
 ) {
     val painter = if (isFullName) brand.fullNameIconPainter() else brand.letterIconPainter()
 
     MaterialIcon(
-        useMaterial3 = useMaterial3,
         painter = painter,
         contentDescription = contentDescription,
         modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
@@ -46,7 +46,7 @@ fun CompletedWorkoutListItem(
     onSaidAwesomeClicked: (isLiked: Boolean) -> Unit,
     isLiked: Boolean,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
@@ -46,7 +46,6 @@ fun CompletedWorkoutListItem(
     onSaidAwesomeClicked: (isLiked: Boolean) -> Unit,
     isLiked: Boolean,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier
@@ -59,8 +58,8 @@ fun CompletedWorkoutListItem(
 
         Column(Modifier.weight(1f), spacedBy(SatsTheme.spacing.m)) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                WorkoutInfo(timestamp, title, location, useMaterial3)
-                MaterialIcon(useMaterial3, SatsTheme.icons.arrowRight, contentDescription = null)
+                WorkoutInfo(timestamp, title, location)
+                MaterialIcon(SatsTheme.icons.arrowRight, contentDescription = null)
             }
 
             SocialRow(
@@ -69,7 +68,6 @@ fun CompletedWorkoutListItem(
                 onSaidAwesomeClicked = onSaidAwesomeClicked,
                 isLiked = isLiked,
                 modifier = Modifier.fillMaxWidth(),
-                useMaterial3 = useMaterial3,
             )
         }
     }
@@ -81,7 +79,6 @@ private fun SocialRow(
     numberOfReactionsLabel: String?,
     onSaidAwesomeClicked: (isLiked: Boolean) -> Unit,
     isLiked: Boolean,
-    useMaterial3: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
@@ -92,13 +89,12 @@ private fun SocialRow(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 MaterialIcon(
-                    useMaterial3,
                     SatsTheme.icons.fistBump,
                     contentDescription = null,
                     tint = SatsTheme.colors.onBackground.secondary,
                 )
 
-                MaterialText(useMaterial3, numberOfReactionsLabel, color = SatsTheme.colors.onBackground.secondary)
+                MaterialText(numberOfReactionsLabel, color = SatsTheme.colors.onBackground.secondary)
             }
         }
 
@@ -113,12 +109,11 @@ private fun SocialRow(
         Row(verticalAlignment = Alignment.CenterVertically) {
             Row(Modifier, spacedBy(SatsTheme.spacing.xs), Alignment.CenterVertically) {
                 MaterialIcon(
-                    useMaterial3,
                     SatsTheme.icons.comment,
                     contentDescription = null,
                     tint = SatsTheme.colors.action.default,
                 )
-                MaterialText(useMaterial3, normalizedNumberOfComments, color = SatsTheme.colors.onBackground.secondary)
+                MaterialText(normalizedNumberOfComments, color = SatsTheme.colors.onBackground.secondary)
             }
 
             LikeButton(isLiked = isLiked, onSaidAwesomeClicked)
@@ -131,22 +126,19 @@ private fun WorkoutInfo(
     timestamp: String,
     title: String,
     subtitle: String?,
-    useMaterial3: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
         MaterialText(
-            useMaterial3,
             timestamp,
             color = SatsTheme.colors.onBackground.secondary,
             style = SatsTheme.typography.default.small,
         )
 
-        MaterialText(useMaterial3, title)
+        MaterialText(title)
 
         if (subtitle != null) {
             MaterialText(
-                useMaterial3,
                 subtitle,
                 color = SatsTheme.colors.onBackground.secondary,
                 style = SatsTheme.typography.default.small,
@@ -172,7 +164,6 @@ private fun Preview() {
                     onCompletedWorkoutClicked = {},
                     onSaidAwesomeClicked = {},
                     isLiked = false,
-                    useMaterial3 = true,
                 )
 
                 Material3Divider()
@@ -187,7 +178,6 @@ private fun Preview() {
                     onCompletedWorkoutClicked = {},
                     onSaidAwesomeClicked = {},
                     isLiked = false,
-                    useMaterial3 = true,
                 )
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/LocalUseMaterial3.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/LocalUseMaterial3.kt
@@ -1,0 +1,5 @@
+package com.sats.dna.components
+
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalUseMaterial3 = compositionLocalOf { false }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
@@ -22,7 +22,7 @@ fun SatsBanner(
     action: @Composable (() -> Unit)? = null,
     backgroundColor: Color = SatsTheme.colors.primary.default,
     contentColor: Color = satsContentColorFor(backgroundColor),
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsSurface(
         modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
@@ -22,13 +22,11 @@ fun SatsBanner(
     action: @Composable (() -> Unit)? = null,
     backgroundColor: Color = SatsTheme.colors.primary.default,
     contentColor: Color = satsContentColorFor(backgroundColor),
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsSurface(
         modifier = modifier,
         color = backgroundColor,
         contentColor = contentColor,
-        useMaterial3 = useMaterial3,
     ) {
         Row(
             Modifier.padding(horizontal = SatsTheme.spacing.m, vertical = SatsTheme.spacing.xs),
@@ -36,7 +34,6 @@ fun SatsBanner(
             horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
         ) {
             MaterialText(
-                useMaterial3 = useMaterial3,
                 text = title,
                 modifier = Modifier.weight(1f),
             )
@@ -50,11 +47,12 @@ fun SatsBanner(
 @Composable
 private fun SatsBannerPreview() {
     SatsTheme {
-        SatsBanner(
-            modifier = Modifier.fillMaxWidth(),
-            title = "Will the real Slim Shady please stand up?",
-            useMaterial3 = true,
-        )
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            SatsBanner(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Will the real Slim Shady please stand up?",
+            )
+        }
     }
 }
 
@@ -62,11 +60,12 @@ private fun SatsBannerPreview() {
 @Composable
 private fun SatsBannerWithActionPreview() {
     SatsTheme {
-        SatsBanner(
-            modifier = Modifier.fillMaxWidth(),
-            title = "Will the real Slim Shady please stand up?",
-            action = { SatsButton(onClick = {}, "Stand up", colors = SatsButtonColor.Clean) },
-            useMaterial3 = true,
-        )
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            SatsBanner(
+                modifier = Modifier.fillMaxWidth(),
+                title = "Will the real Slim Shady please stand up?",
+                action = { SatsButton(onClick = {}, "Stand up", colors = SatsButtonColor.Clean) },
+            )
+        }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -25,18 +26,20 @@ fun SatsCampaignModule(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    SatsCard(modifier, useMaterial3 = true) {
-        Column(Modifier.clickable { onClick() }) {
-            HeroImage(imageUrl)
+    CompositionLocalProvider(LocalUseMaterial3 provides true) {
+        SatsCard(modifier) {
+            Column(Modifier.clickable { onClick() }) {
+                HeroImage(imageUrl)
 
-            Column(
-                Modifier.padding(SatsTheme.spacing.m),
-                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs),
-            ) {
-                Text(title, style = SatsTheme.typography.medium.basic)
+                Column(
+                    Modifier.padding(SatsTheme.spacing.m),
+                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs),
+                ) {
+                    Text(title, style = SatsTheme.typography.medium.basic)
 
-                if (subtitle != null) {
-                    Text(subtitle, style = SatsTheme.typography.default.small)
+                    if (subtitle != null) {
+                        Text(subtitle, style = SatsTheme.typography.default.small)
+                    }
                 }
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
@@ -36,7 +36,6 @@ fun SatsFilterChip(
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
     colors: SatsFilterChipColors = SatsChipDefaults.filterChipColors(),
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     val backgroundColor = colors.backgroundColor(
         isSelected = isSelected,
@@ -57,11 +56,9 @@ fun SatsFilterChip(
         backgroundColor = backgroundColor.value,
         contentColor = contentColor.value,
         borderColor = borderColor.value,
-        useMaterial3 = useMaterial3,
         modifier = modifier,
     ) {
         MaterialText(
-            useMaterial3 = useMaterial3,
             text = text,
             modifier = Modifier
                 .clickable(enabled = isEnabled, role = Role.Switch) { onClick() }
@@ -78,7 +75,6 @@ fun SatsInputChip(
     action: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     colors: SatsInputChipColors = SatsChipDefaults.inputChipColors(),
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     val backgroundColor = colors.backgroundColor().value
     val contentColor = colors.contentColor().value
@@ -87,7 +83,6 @@ fun SatsInputChip(
         backgroundColor = backgroundColor,
         contentColor = contentColor,
         borderColor = null,
-        useMaterial3 = useMaterial3,
         modifier = modifier.width(IntrinsicSize.Max),
     ) {
         Row(
@@ -96,7 +91,6 @@ fun SatsInputChip(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             MaterialText(
-                useMaterial3 = useMaterial3,
                 text = text,
                 modifier = Modifier.weight(1f),
                 maxLines = 1,
@@ -113,7 +107,6 @@ fun SatsInputChipClearButton(
     onClick: () -> Unit,
     onClickLabel: String?,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsSurface(
         modifier = modifier.size(16.dp),
@@ -121,7 +114,6 @@ fun SatsInputChipClearButton(
         shape = SatsTheme.shapes.circle,
     ) {
         MaterialIcon(
-            useMaterial3 = useMaterial3,
             painter = SatsTheme.icons.close,
             contentDescription = null,
             modifier = Modifier.clickable(onClickLabel = onClickLabel, role = Role.Button) { onClick() },
@@ -135,11 +127,10 @@ private fun SatsChipLayout(
     backgroundColor: Color,
     contentColor: Color,
     borderColor: Color?,
-    useMaterial3: Boolean,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    if (useMaterial3) {
+    if (LocalUseMaterial3.current) {
         Material3Surface(
             modifier,
             shape = SatsTheme.shapes.roundedCorners.extraSmall,
@@ -292,7 +283,6 @@ private fun SatsFilterChipPreview() {
                         isSelected = false,
                         isEnabled = true,
                         onClick = { },
-                        useMaterial3 = true,
                     )
 
                     SatsFilterChip(
@@ -300,7 +290,6 @@ private fun SatsFilterChipPreview() {
                         isSelected = true,
                         isEnabled = true,
                         onClick = { },
-                        useMaterial3 = true,
                     )
                 }
 
@@ -313,7 +302,6 @@ private fun SatsFilterChipPreview() {
                         isSelected = false,
                         isEnabled = false,
                         onClick = { },
-                        useMaterial3 = true,
                     )
 
                     SatsFilterChip(
@@ -321,7 +309,6 @@ private fun SatsFilterChipPreview() {
                         isSelected = true,
                         isEnabled = false,
                         onClick = { },
-                        useMaterial3 = true,
                     )
                 }
             }
@@ -341,13 +328,11 @@ private fun SatsInputChipPreview() {
                 SatsInputChip(
                     text = "Oslo",
                     action = { SatsInputChipClearButton(onClick = {}, onClickLabel = "Clear") },
-                    useMaterial3 = true,
                 )
 
                 SatsInputChip(
                     text = "(4) Akersgata, Bislett, Storo, Nydalen",
                     action = { SatsInputChipClearButton(onClick = {}, onClickLabel = "Clear") },
-                    useMaterial3 = true,
                 )
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
@@ -36,7 +36,7 @@ fun SatsFilterChip(
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
     colors: SatsFilterChipColors = SatsChipDefaults.filterChipColors(),
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     val backgroundColor = colors.backgroundColor(
         isSelected = isSelected,
@@ -78,7 +78,7 @@ fun SatsInputChip(
     action: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     colors: SatsInputChipColors = SatsChipDefaults.inputChipColors(),
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     val backgroundColor = colors.backgroundColor().value
     val contentColor = colors.contentColor().value
@@ -113,7 +113,7 @@ fun SatsInputChipClearButton(
     onClick: () -> Unit,
     onClickLabel: String?,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsSurface(
         modifier = modifier.size(16.dp),

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
@@ -33,9 +33,8 @@ fun SatsGeneralListItem(
     trailingContent: @Composable (() -> Unit)? = null,
     colors: SatsGeneralListItemColors = SatsGeneralListItemDefaults.generalListItemColors(),
     isEnabled: Boolean = true,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
-    SatsSurface(modifier, useMaterial3 = useMaterial3) {
+    SatsSurface(modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
@@ -48,7 +47,6 @@ fun SatsGeneralListItem(
         ) {
             icon?.let {
                 MaterialIcon(
-                    useMaterial3,
                     it,
                     null,
                     tint = colors.iconColor,
@@ -56,9 +54,9 @@ fun SatsGeneralListItem(
                 )
             }
             Column(Modifier.weight(1f)) {
-                MaterialText(useMaterial3, title, color = colors.titleColor)
+                MaterialText(title, color = colors.titleColor)
                 subtitle?.let {
-                    MaterialText(useMaterial3, it, color = colors.subtitleColor)
+                    MaterialText(it, color = colors.subtitleColor)
                 }
             }
             trailingContent?.let {
@@ -72,25 +70,23 @@ object TrailingContent {
     @Composable
     fun Icon(
         icon: Painter,
-        useMaterial3: Boolean = LocalUseMaterial3.current,
-        tint: Color = materialIconTint(useMaterial3),
+        tint: Color = materialIconTint(),
     ) {
-        MaterialIcon(useMaterial3, icon, null, tint = tint, modifier = Modifier.size(18.dp))
+        MaterialIcon(icon, null, tint = tint, modifier = Modifier.size(18.dp))
     }
 
     @Composable
     fun TextAndIcon(
         text: String,
         icon: Painter,
-        useMaterial3: Boolean = LocalUseMaterial3.current,
-        tint: Color = materialIconTint(useMaterial3),
+        tint: Color = materialIconTint(),
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            MaterialText(useMaterial3, text, color = tint)
-            MaterialIcon(useMaterial3, icon, null, tint = tint, modifier = Modifier.size(18.dp))
+            MaterialText(text, color = tint)
+            MaterialIcon(icon, null, tint = tint, modifier = Modifier.size(18.dp))
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
@@ -33,7 +33,7 @@ fun SatsGeneralListItem(
     trailingContent: @Composable (() -> Unit)? = null,
     colors: SatsGeneralListItemColors = SatsGeneralListItemDefaults.generalListItemColors(),
     isEnabled: Boolean = true,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsSurface(modifier, useMaterial3 = useMaterial3) {
         Row(
@@ -72,7 +72,7 @@ object TrailingContent {
     @Composable
     fun Icon(
         icon: Painter,
-        useMaterial3: Boolean = false,
+        useMaterial3: Boolean = LocalUseMaterial3.current,
         tint: Color = materialIconTint(useMaterial3),
     ) {
         MaterialIcon(useMaterial3, icon, null, tint = tint, modifier = Modifier.size(18.dp))
@@ -82,7 +82,7 @@ object TrailingContent {
     fun TextAndIcon(
         text: String,
         icon: Painter,
-        useMaterial3: Boolean = false,
+        useMaterial3: Boolean = LocalUseMaterial3.current,
         tint: Color = materialIconTint(useMaterial3),
     ) {
         Row(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
@@ -2,6 +2,7 @@ package com.sats.dna.components
 
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -22,23 +23,25 @@ fun SatsSurface(
     useMaterial3: Boolean = LocalUseMaterial3.current,
     content: @Composable () -> Unit,
 ) {
-    if (useMaterial3) {
-        Material3Surface(
-            modifier = modifier,
-            shape = shape,
-            color = color,
-            contentColor = contentColor,
-            shadowElevation = elevation,
-            content = content,
-        )
-    } else {
-        Surface(
-            modifier = modifier,
-            shape = shape,
-            color = color,
-            contentColor = contentColor,
-            elevation = elevation,
-            content = content,
-        )
+    CompositionLocalProvider(LocalUseMaterial3 provides useMaterial3) {
+        if (useMaterial3) {
+            Material3Surface(
+                modifier = modifier,
+                shape = shape,
+                color = color,
+                contentColor = contentColor,
+                shadowElevation = elevation,
+                content = content,
+            )
+        } else {
+            Surface(
+                modifier = modifier,
+                shape = shape,
+                color = color,
+                contentColor = contentColor,
+                elevation = elevation,
+                content = content,
+            )
+        }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
@@ -19,7 +19,7 @@ fun SatsSurface(
     contentColor: Color = satsContentColorFor(color),
     shape: Shape = RectangleShape,
     elevation: Dp = 0.dp,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
     content: @Composable () -> Unit,
 ) {
     if (useMaterial3) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
@@ -8,19 +8,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun LikeButton(
     isLiked: Boolean,
     onLikedChange: (isLiked: Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     IconToggleButton(modifier = modifier, checked = isLiked, onCheckedChange = onLikedChange) {
         if (isLiked) {
@@ -28,20 +26,18 @@ fun LikeButton(
                 painter = SatsTheme.icons.fistBumpFilled,
                 tint = SatsTheme.colors.action.default,
                 contentDescription = null,
-                useMaterial3 = useMaterial3,
             )
         } else {
             MaterialIcon(
                 painter = SatsTheme.icons.fistBump,
                 tint = SatsTheme.colors.action.default,
                 contentDescription = null,
-                useMaterial3 = useMaterial3,
             )
         }
     }
 }
 
-@Preview
+@LightDarkPreview
 @Composable
 private fun LikedPreview() {
     var isLiked by remember { mutableStateOf(true) }
@@ -53,7 +49,7 @@ private fun LikedPreview() {
     }
 }
 
-@Preview
+@LightDarkPreview
 @Composable
 private fun NotLikedPreview() {
     var isLiked by remember { mutableStateOf(false) }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
@@ -1,7 +1,6 @@
 package com.sats.dna.components.button
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -11,7 +10,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSurface
+import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
 
 @Composable
@@ -19,13 +20,23 @@ fun LikeButton(
     isLiked: Boolean,
     onLikedChange: (isLiked: Boolean) -> Unit,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     IconToggleButton(modifier = modifier, checked = isLiked, onCheckedChange = onLikedChange) {
         if (isLiked) {
-            Icon(SatsTheme.icons.fistBumpFilled, tint = SatsTheme.colors.action.default, contentDescription = null)
+            MaterialIcon(
+                painter = SatsTheme.icons.fistBumpFilled,
+                tint = SatsTheme.colors.action.default,
+                contentDescription = null,
+                useMaterial3 = useMaterial3,
+            )
         } else {
-            Icon(SatsTheme.icons.fistBump, tint = SatsTheme.colors.action.default, contentDescription = null)
+            MaterialIcon(
+                painter = SatsTheme.icons.fistBump,
+                tint = SatsTheme.colors.action.default,
+                contentDescription = null,
+                useMaterial3 = useMaterial3,
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -7,15 +7,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.LocalUseMaterial3
+import com.sats.dna.components.SatsSurface
+import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.Card as M2Card
@@ -23,10 +24,9 @@ import androidx.compose.material.Card as M2Card
 @Composable
 fun SatsCard(
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
     content: @Composable () -> Unit,
 ) {
-    if (useMaterial3) {
+    if (LocalUseMaterial3.current) {
         ElevatedCard(
             modifier = modifier,
             shape = SatsTheme.shapes.roundedCorners.small,
@@ -51,24 +51,35 @@ fun SatsCard(
 
 @LightDarkPreview
 @Composable
-private fun Preview() {
+private fun Material3Preview() {
     SatsTheme {
-        Surface(color = SatsTheme.colors.background.primary) {
-            SatsCard(Modifier.padding(SatsTheme.spacing.m), useMaterial3 = true) {
-                Column {
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9)
-                            .background(SatsTheme.colors.waitingList.primary),
-                    ) {
-                        Text("Image", Modifier.align(Alignment.Center), color = SatsTheme.colors.onWaitingList.primary)
-                    }
+        CompositionLocalProvider(LocalUseMaterial3 provides true) {
+            SatsSurface(color = SatsTheme.colors.background.primary) {
+                SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
+                    Column {
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(16f / 9)
+                                .background(SatsTheme.colors.waitingList.primary),
+                        ) {
+                            MaterialText(
+                                text = "Image",
+                                modifier = Modifier.align(Alignment.Center),
+                                color = SatsTheme.colors.onWaitingList.primary,
+                            )
+                        }
 
-                    Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Material 3", style = SatsTheme.typography.medium.large)
+                        Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
+                            MaterialText(
+                                text = "Material 3",
+                                style = SatsTheme.typography.medium.large,
+                            )
 
-                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+                            MaterialText(
+                                text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                            )
+                        }
                     }
                 }
             }
@@ -80,22 +91,33 @@ private fun Preview() {
 @Composable
 private fun Material2Preview() {
     SatsTheme {
-        Surface(color = SatsTheme.colors.background.primary) {
-            SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
-                Column {
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9)
-                            .background(SatsTheme.colors.waitingList.primary),
-                    ) {
-                        Text("Image", Modifier.align(Alignment.Center), color = SatsTheme.colors.onWaitingList.primary)
-                    }
+        CompositionLocalProvider(LocalUseMaterial3 provides false) {
+            SatsSurface(color = SatsTheme.colors.background.primary) {
+                SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
+                    Column {
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(16f / 9)
+                                .background(SatsTheme.colors.waitingList.primary),
+                        ) {
+                            MaterialText(
+                                text = "Image",
+                                modifier = Modifier.align(Alignment.Center),
+                                color = SatsTheme.colors.onWaitingList.primary,
+                            )
+                        }
 
-                    Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Material 2", style = SatsTheme.typography.medium.large)
+                        Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
+                            MaterialText(
+                                text = "Material 2",
+                                style = SatsTheme.typography.medium.large,
+                            )
 
-                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+                            MaterialText(
+                                text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                            )
+                        }
                     }
                 }
             }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -15,12 +15,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.Card as M2Card
 
 @Composable
-fun SatsCard(modifier: Modifier = Modifier, useMaterial3: Boolean = false, content: @Composable () -> Unit) {
+fun SatsCard(
+    modifier: Modifier = Modifier,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
+    content: @Composable () -> Unit,
+) {
     if (useMaterial3) {
         ElevatedCard(
             modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
@@ -9,11 +9,13 @@ import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.insets.ui.Scaffold
+import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSnackbar
 import com.sats.dna.components.SatsSnackbarAction
 import com.sats.dna.theme.SatsTheme
@@ -34,16 +36,18 @@ fun SatsScreen(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable (contentPadding: PaddingValues) -> Unit,
 ) {
-    Scaffold(
-        modifier = modifier,
-        scaffoldState = scaffoldState,
-        topBar = topBar,
-        bottomBar = bottomBar,
-        snackbarHost = snackbarHost,
-        floatingActionButton = floatingActionButton,
-        contentPadding = contentPadding,
-        content = content,
-    )
+    CompositionLocalProvider(LocalUseMaterial3 provides false) {
+        Scaffold(
+            modifier = modifier,
+            scaffoldState = scaffoldState,
+            topBar = topBar,
+            bottomBar = bottomBar,
+            snackbarHost = snackbarHost,
+            floatingActionButton = floatingActionButton,
+            contentPadding = contentPadding,
+            content = content,
+        )
+    }
 }
 
 @Composable
@@ -59,23 +63,25 @@ fun M3SatsScreen(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable (contentPadding: PaddingValues) -> Unit,
 ) {
-    M3Scaffold(
-        modifier = modifier,
-        topBar = topBar,
-        bottomBar = bottomBar,
-        snackbarHost = { snackbarHost(snackbarHostState) },
-        floatingActionButton = floatingActionButton,
-    ) { scaffoldContentPadding ->
-        val screenContentPadding = PaddingValues(
-            start = scaffoldContentPadding.calculateStartPadding(LocalLayoutDirection.current) +
-                contentPadding.calculateStartPadding(LocalLayoutDirection.current),
-            top = scaffoldContentPadding.calculateTopPadding() + contentPadding.calculateTopPadding(),
-            end = scaffoldContentPadding.calculateEndPadding(LocalLayoutDirection.current) +
-                contentPadding.calculateEndPadding(LocalLayoutDirection.current),
-            bottom = scaffoldContentPadding.calculateBottomPadding() + contentPadding.calculateBottomPadding(),
-        )
+    CompositionLocalProvider(LocalUseMaterial3 provides true) {
+        M3Scaffold(
+            modifier = modifier,
+            topBar = topBar,
+            bottomBar = bottomBar,
+            snackbarHost = { snackbarHost(snackbarHostState) },
+            floatingActionButton = floatingActionButton,
+        ) { scaffoldContentPadding ->
+            val screenContentPadding = PaddingValues(
+                start = scaffoldContentPadding.calculateStartPadding(LocalLayoutDirection.current) +
+                    contentPadding.calculateStartPadding(LocalLayoutDirection.current),
+                top = scaffoldContentPadding.calculateTopPadding() + contentPadding.calculateTopPadding(),
+                end = scaffoldContentPadding.calculateEndPadding(LocalLayoutDirection.current) +
+                    contentPadding.calculateEndPadding(LocalLayoutDirection.current),
+                bottom = scaffoldContentPadding.calculateBottomPadding() + contentPadding.calculateBottomPadding(),
+            )
 
-        content(screenContentPadding)
+            content(screenContentPadding)
+        }
     }
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
@@ -19,7 +20,7 @@ fun Schedule(
     workouts: List<ScheduledWorkout>,
     onWorkoutClicked: (workout: ScheduledWorkout) -> Unit,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     SatsCard(modifier.fillMaxWidth(), useMaterial3 = true) {
         val days = workouts.groupBy { it.day }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
@@ -20,12 +19,11 @@ fun Schedule(
     workouts: List<ScheduledWorkout>,
     onWorkoutClicked: (workout: ScheduledWorkout) -> Unit,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
-    SatsCard(modifier.fillMaxWidth(), useMaterial3 = true) {
+    SatsCard(modifier.fillMaxWidth()) {
         val days = workouts.groupBy { it.day }
 
-        ScheduledDays(days, onWorkoutClicked, useMaterial3 = useMaterial3)
+        ScheduledDays(days, onWorkoutClicked)
     }
 }
 
@@ -33,7 +31,6 @@ fun Schedule(
 private fun ScheduledDays(
     days: Map<String, List<ScheduledWorkout>>,
     onWorkoutClicked: (workout: ScheduledWorkout) -> Unit,
-    useMaterial3: Boolean,
 ) {
     Column(
         Modifier.padding(top = cardInnerPadding, bottom = cardInnerPadding - clickableVerticalPadding),
@@ -42,7 +39,6 @@ private fun ScheduledDays(
         days.keys.forEach { dayName ->
             Column(verticalArrangement = spacedBy(SatsTheme.spacing.s - clickableVerticalPadding)) {
                 MaterialText(
-                    useMaterial3 = useMaterial3,
                     text = dayName,
                     modifier = Modifier.padding(horizontal = cardInnerPadding),
                     color = SatsTheme.colors.onSurface.secondary,
@@ -51,7 +47,7 @@ private fun ScheduledDays(
 
                 val workouts = days.getValue(dayName)
 
-                ScheduledWorkouts(workouts, onWorkoutClicked, useMaterial3)
+                ScheduledWorkouts(workouts, onWorkoutClicked)
             }
         }
     }
@@ -61,7 +57,6 @@ private fun ScheduledDays(
 private fun ScheduledWorkouts(
     workouts: List<ScheduledWorkout>,
     onWorkoutClicked: (workout: ScheduledWorkout) -> Unit,
-    useMaterial3: Boolean,
 ) {
     Column(verticalArrangement = spacedBy(SatsTheme.spacing.xs - clickableVerticalPadding)) {
         workouts.forEach { workout ->
@@ -81,7 +76,6 @@ private fun ScheduledWorkouts(
                     time = workout.time,
                     duration = workout.duration,
                     modifier = Modifier.weight(1f),
-                    useMaterial3 = useMaterial3,
                 )
 
                 WorkoutInfo(
@@ -90,7 +84,6 @@ private fun ScheduledWorkouts(
                     instructor = workout.instructor,
                     waitingListStatus = workout.waitingListStatus,
                     modifier = Modifier.weight(4f),
-                    useMaterial3 = useMaterial3,
                 )
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
@@ -13,18 +13,15 @@ import com.sats.dna.tooling.LightDarkPreview
 internal fun TimeAndDuration(
     time: String,
     duration: String,
-    useMaterial3: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
         MaterialText(
-            useMaterial3 = useMaterial3,
             text = time,
             style = SatsTheme.typography.medium.basic,
         )
 
         MaterialText(
-            useMaterial3 = useMaterial3,
             text = duration,
             style = SatsTheme.typography.default.small,
             color = SatsTheme.colors.onBackground.secondary,
@@ -37,46 +34,41 @@ internal fun WorkoutInfo(
     name: String,
     location: String,
     instructor: String,
-    useMaterial3: Boolean,
     modifier: Modifier = Modifier,
     waitingListStatus: WaitingListStatus? = null,
 ) {
     Column(modifier) {
         MaterialText(
-            useMaterial3,
-            name,
+            text = name,
             style = SatsTheme.typography.medium.basic,
         )
 
         MaterialText(
-            useMaterial3,
-            location,
+            text = location,
             color = SatsTheme.colors.onSurface.secondary,
             style = SatsTheme.typography.default.small,
         )
 
         MaterialText(
-            useMaterial3,
-            instructor,
+            text = instructor,
             style = SatsTheme.typography.default.small,
             color = SatsTheme.colors.onBackground.secondary,
         )
 
         waitingListStatus?.let { status ->
-            WaitingListStatus(status, useMaterial3)
+            WaitingListStatus(status)
         }
     }
 }
 
 @Composable
-private fun WaitingListStatus(status: WaitingListStatus, useMaterial3: Boolean) {
+private fun WaitingListStatus(status: WaitingListStatus) {
     val color = when (status) {
         is WaitingListStatus.OnWaitingList -> SatsTheme.colors.waitingList.text
         is WaitingListStatus.SpotSecured -> SatsTheme.colors.signalText.success
     }
 
     MaterialText(
-        useMaterial3 = useMaterial3,
         text = status.text,
         color = color,
         style = SatsTheme.typography.default.small,
@@ -85,7 +77,6 @@ private fun WaitingListStatus(status: WaitingListStatus, useMaterial3: Boolean) 
     if (status is WaitingListStatus.SpotSecured) {
         status.waitingListText?.let {
             MaterialText(
-                useMaterial3,
                 text = status.waitingListText,
                 color = SatsTheme.colors.waitingList.text,
                 style = SatsTheme.typography.default.small,
@@ -103,7 +94,6 @@ private fun TimeAndDurationPreview() {
                 time = "9:00 PM",
                 duration = "45 min",
                 modifier = Modifier.padding(SatsTheme.spacing.m),
-                useMaterial3 = true,
             )
         }
     }
@@ -120,7 +110,6 @@ private fun WorkoutInfoPreview() {
                 instructor = "w/ Andrew Nielsen",
                 waitingListStatus = WaitingListStatus.SpotSecured("Spot secured! 32 on the waiting list."),
                 modifier = Modifier.padding(SatsTheme.spacing.m),
-                useMaterial3 = true,
             )
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsButton
@@ -39,13 +38,11 @@ import com.sats.dna.tooling.LightDarkPreview
 fun UpcomingWorkoutDaySection(
     day: String,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(modifier) {
-        SatsSurface(Modifier.fillMaxWidth(), elevation = 1.dp, useMaterial3 = useMaterial3) {
+        SatsSurface(Modifier.fillMaxWidth(), elevation = 1.dp) {
             MaterialText(
-                useMaterial3 = useMaterial3,
                 text = day,
                 modifier = Modifier.padding(
                     vertical = SatsTheme.spacing.s,
@@ -83,7 +80,6 @@ fun UpcomingWorkoutListItem(
     button: @Composable (() -> Unit)? = null,
     friendsAttending: @Composable (ColumnScope.() -> Unit)? = null,
     waitingListStatus: WaitingListStatus? = null,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier
@@ -94,7 +90,6 @@ fun UpcomingWorkoutListItem(
         TimeAndDuration(
             time = time,
             duration = duration,
-            useMaterial3 = useMaterial3,
         )
 
         Column(
@@ -111,7 +106,6 @@ fun UpcomingWorkoutListItem(
                     instructor = instructor,
                     waitingListStatus = waitingListStatus,
                     modifier = Modifier.weight(1f),
-                    useMaterial3 = useMaterial3,
                 )
 
                 button?.let { it() }
@@ -136,7 +130,6 @@ fun UpcomingWorkoutAttendingFriendsLabel(
     memberImages: @Composable RowScope.() -> Unit,
     friendsAttendingLabel: String,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier = modifier,
@@ -147,7 +140,7 @@ fun UpcomingWorkoutAttendingFriendsLabel(
             memberImages()
         }
 
-        MaterialText(useMaterial3, friendsAttendingLabel)
+        MaterialText(friendsAttendingLabel)
     }
 }
 
@@ -158,7 +151,7 @@ private fun UpcomingWorkoutsListPreview() {
     SatsTheme {
         SatsSurface(useMaterial3 = true) {
             Column {
-                UpcomingWorkoutDaySection(day = "Thu, Jul 27 2023", useMaterial3 = true) {
+                UpcomingWorkoutDaySection(day = "Thu, Jul 27 2023") {
                     UpcomingWorkoutListItem(
                         name = "Pure Strength",
                         time = "11:00 AM",
@@ -189,11 +182,9 @@ private fun UpcomingWorkoutsListPreview() {
                                     )
                                 },
                                 friendsAttendingLabel = "2 friends are joining this workout!",
-                                useMaterial3 = true,
                             )
                         },
                         onClick = {},
-                        useMaterial3 = true,
                     )
                 }
             }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsButton
@@ -38,7 +39,7 @@ import com.sats.dna.tooling.LightDarkPreview
 fun UpcomingWorkoutDaySection(
     day: String,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(modifier) {
@@ -82,7 +83,7 @@ fun UpcomingWorkoutListItem(
     button: @Composable (() -> Unit)? = null,
     friendsAttending: @Composable (ColumnScope.() -> Unit)? = null,
     waitingListStatus: WaitingListStatus? = null,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier
@@ -135,7 +136,7 @@ fun UpcomingWorkoutAttendingFriendsLabel(
     memberImages: @Composable RowScope.() -> Unit,
     friendsAttendingLabel: String,
     modifier: Modifier = Modifier,
-    useMaterial3: Boolean = false,
+    useMaterial3: Boolean = LocalUseMaterial3.current,
 ) {
     Row(
         modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
@@ -1,9 +1,14 @@
 package com.sats.dna.internal
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import com.sats.dna.components.LocalUseMaterial3
+import com.sats.dna.components.SatsSurface
+import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.Icon as Material2Icon
 import androidx.compose.material.LocalContentAlpha as Material2LocalContentAlpha
 import androidx.compose.material.LocalContentColor as Material2LocalContentColor
@@ -12,13 +17,12 @@ import androidx.compose.material3.LocalContentColor as Material3LocalContentColo
 
 @Composable
 internal fun MaterialIcon(
-    useMaterial3: Boolean,
     painter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    tint: Color = materialIconTint(useMaterial3),
+    tint: Color = materialIconTint(),
 ) {
-    if (useMaterial3) {
+    if (LocalUseMaterial3.current) {
         Material3Icon(painter, contentDescription, modifier, tint)
     } else {
         Material2Icon(painter, contentDescription, modifier, tint)
@@ -26,10 +30,30 @@ internal fun MaterialIcon(
 }
 
 @Composable
-internal fun materialIconTint(useMaterial3: Boolean): Color {
-    return if (useMaterial3) {
+internal fun materialIconTint(): Color {
+    return if (LocalUseMaterial3.current) {
         Material3LocalContentColor.current
     } else {
         Material2LocalContentColor.current.copy(alpha = Material2LocalContentAlpha.current)
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun M2Preview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = false) {
+            MaterialIcon(SatsTheme.icons.barbell, contentDescription = null, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun M3Preview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.background.primary, useMaterial3 = true) {
+            MaterialIcon(SatsTheme.icons.barbell, contentDescription = null, Modifier.padding(SatsTheme.spacing.m))
+        }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialText.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialText.kt
@@ -6,12 +6,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import com.sats.dna.components.LocalUseMaterial3
 import androidx.compose.material.Text as Material2Text
 import androidx.compose.material3.Text as Material3Text
 
 @Composable
 internal fun MaterialText(
-    useMaterial3: Boolean,
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
@@ -19,7 +19,7 @@ internal fun MaterialText(
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
 ) {
-    if (useMaterial3) {
+    if (LocalUseMaterial3.current) {
         Material3Text(
             text = text,
             modifier = modifier,


### PR DESCRIPTION
This lets us not have to pass `useMaterial3` around all over the place.
Instead, we set it on the top (screen) level, and then it defaults to
whichever screen was set further down the line.

Before, we had to do something like this:

```kt
M3SatsScreen {
  SatsSurface(useMaterial3 = true) {
    SatsBanner("Banner text", useMaterial3 = true)
  }
}
```

Now, it should be enough just to use an `M3SatsScreen`, and the
components will respect the Composition Local:

```kt
M3SatsScreen {
  SatsSurface {
    SatsBanner("Banner text")
  }
}
```

In fact, I've removed the `useMaterial3: Boolean` parameter from all components except for `SatsSurface`. The only way to explicitly change this now is through `LocalUseMaterial3`. This avoids ambiguity and simplifies an otherwise complex API surface.

The reason for keeping it for `SatsSurface` is because we wrap pretty much all of our components in that in previews, and it would be very annoying to have to wrap all of those in `CompositionLocalProvider`s when migrating them to Material 3. `SatsSurface` will propagate its `useMaterial3: Boolean` down the chain by “resetting” `LocalUseMaterial3` to whatever was passed in, and it still defaults to `LocalUseMaterial3.current`.