### PR TITLE
NMA-5788: Update dark mode color for Rewards Blue

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsDark.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColorsDark.kt
@@ -133,7 +133,7 @@ internal val SatsDarkColors = SatsColors(
     onSignal = Color(0xFFFFFFFF),
 
     rewards = SatsColors.Rewards(
-        blue = Color(0xFF2676B0),
+        blue = Color(0xFF3D8DC7),
         silver = Color(0xFFCAD1D8),
         gold = Color(0xFFD4A852),
         platinum = Color(0xFF929AA1),


### PR DESCRIPTION
The previous color was not compliant with the On Rewards color.
