### PR TITLE
NMA-5907: Create placeholders for info labels

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SessionDetailsInfoLabelSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SessionDetailsInfoLabelSampleScreen.kt
@@ -1,16 +1,16 @@
 package com.sats.dna.sample.screens
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import com.sats.dna.components.LocalUseMaterial3
-import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.sessiondetails.SessionDetailsInfoLabel
 import com.sats.dna.components.sessiondetails.SessionDetailsInfoSection
+import com.sats.dna.components.sessiondetails.SessionDetailsInfoSectionPlaceholder
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
@@ -22,44 +22,51 @@ data object SessionDetailsInfoLabelSampleScreen : SampleScreen(
 
 @Composable
 private fun SessionDetailsInfoLabelScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
-    ComponentScreen(
-        title = "Friends Booking Status",
-        navigateUp = navigateUp,
-        modifier = modifier,
-    ) { innerPadding ->
+    ComponentScreen("Session Details Info Label", navigateUp, modifier) { innerPadding ->
         Column(
             Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
                 .wrapContentSize(),
+            verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
         ) {
-            CompositionLocalProvider(
-                LocalUseMaterial3 provides false,
-            ) {
-                SatsSurface {
-                    SessionDetailsInfoSection(
-                        durationLabel = {
-                            SessionDetailsInfoLabel(
-                                icon = SatsTheme.icons.time,
-                                text = "60 min",
-                            )
-                        },
-                        dateLabel = {
-                            SessionDetailsInfoLabel(
-                                icon = SatsTheme.icons.calendar,
-                                text = "Sat, Dec 2 2:30 PM",
-                            )
-                        },
-                        locationLabel = {
-                            SessionDetailsInfoLabel(
-                                icon = SatsTheme.icons.location,
-                                text = "SATS Bergen LHG",
-                                onClick = {},
-                            )
-                        },
+            SessionDetailsInfoSection(
+                durationLabel = {
+                    SessionDetailsInfoLabel(
+                        icon = SatsTheme.icons.time,
+                        text = "60 min",
                     )
-                }
-            }
+                },
+                dateLabel = {
+                    SessionDetailsInfoLabel(
+                        icon = SatsTheme.icons.calendar,
+                        text = "Sat, Dec 2 2:30 PM",
+                    )
+                },
+                locationLabel = {
+                    SessionDetailsInfoLabel(
+                        icon = SatsTheme.icons.location,
+                        text = "SATS Bergen LHG",
+                        onClick = {},
+                    )
+                },
+                workoutTypeLabel = {
+                    SessionDetailsInfoLabel(
+                        icon = SatsTheme.icons.workoutGx,
+                        text = "Strength Training",
+                    )
+                },
+                gxNameLabel = {
+                    SessionDetailsInfoLabel(
+                        icon = SatsTheme.icons.workoutPt,
+                        text = "Pure Strength",
+                    )
+                },
+            )
+
+            Divider()
+
+            SessionDetailsInfoSectionPlaceholder()
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.PlaceholderBox
+import com.sats.dna.components.PlaceholderText
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
@@ -36,9 +37,9 @@ fun SessionDetailsInfoSection(
     durationLabel: @Composable () -> Unit,
     dateLabel: @Composable () -> Unit,
     locationLabel: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
     workoutTypeLabel: (@Composable () -> Unit)?,
     gxNameLabel: (@Composable () -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier
@@ -97,13 +98,13 @@ fun SessionDetailsInfoLabel(
         horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        CompositionLocalProvider(
-            LocalContentColor provides if (onClick != null) {
-                SatsTheme.colors.action.default
-            } else {
-                LocalContentColor.current
-            },
-        ) {
+        val contentColor = if (onClick == null) {
+            SatsTheme.colors.onBackground.primary
+        } else {
+            SatsTheme.colors.action.default
+        }
+
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
             Icon(icon, contentDescription = null, Modifier.size(20.dp))
             Text(text)
         }
@@ -116,61 +117,49 @@ fun SessionDetailsSectionPlaceholder(
     showDurationLabel: Boolean = true,
     showDateLabel: Boolean = true,
     showLocationLabel: Boolean = true,
-    showWorkoutTypeLabel: Boolean = false,
+    showWorkoutTypeLabel: Boolean = true,
+    showGxNameLabel: Boolean = true,
 ) {
     SessionDetailsInfoSection(
         modifier = modifier,
         durationLabel = {
             if (showDurationLabel) {
-                PlaceholderBox {
-                    SessionDetailsInfoLabel(
-                        icon = SatsTheme.icons.time,
-                        text = "60 minutes",
-                    )
-                }
+                SessionDetailsInfoLabelPlaceholder("60 min")
             }
         },
         dateLabel = {
             if (showDateLabel) {
-                PlaceholderBox {
-                    SessionDetailsInfoLabel(
-                        icon = SatsTheme.icons.calendar,
-                        text = "7.des., 10:30",
-                    )
-                }
+                SessionDetailsInfoLabelPlaceholder("Sat, Dec 2 2:30 PM")
             }
         },
         locationLabel = {
             if (showLocationLabel) {
-                PlaceholderBox {
-                    SessionDetailsInfoLabel(
-                        icon = SatsTheme.icons.location,
-                        text = "SATS Sagene",
-                    )
-                }
+                SessionDetailsInfoLabelPlaceholder("SATS Bergen LHG")
             }
         },
         workoutTypeLabel = {
             if (showWorkoutTypeLabel) {
-                PlaceholderBox {
-                    SessionDetailsInfoLabel(
-                        icon = SatsTheme.icons.workoutGymFloor,
-                        text = "Strength Training",
-                    )
-                }
+                SessionDetailsInfoLabelPlaceholder("Strength Training")
             }
         },
         gxNameLabel = {
-            if (showWorkoutTypeLabel) {
-                PlaceholderBox {
-                    SessionDetailsInfoLabel(
-                        icon = SatsTheme.icons.workoutGymFloor,
-                        text = "Pure Strength",
-                    )
-                }
+            if (showGxNameLabel) {
+                SessionDetailsInfoLabelPlaceholder("Pure Strength")
             }
         },
     )
+}
+
+@Composable
+fun SessionDetailsInfoLabelPlaceholder(text: String, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.padding(horizontal = SatsTheme.spacing.m, vertical = SatsTheme.spacing.xs),
+        horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PlaceholderBox(Modifier.size(20.dp), SatsTheme.shapes.circle)
+        PlaceholderText(text)
+    }
 }
 
 @LightDarkPreview
@@ -220,8 +209,22 @@ private fun SessionDetailsInfoSectionPreview() {
 private fun SessionDetailsInfoSectionPlaceholderPreview() {
     SatsTheme {
         SatsSurface {
-            SessionDetailsSectionPlaceholder(
-                Modifier.padding(horizontal = SatsTheme.spacing.m),
+            SessionDetailsSectionPlaceholder()
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SessionDetailsInfoLabelPlaceholderPreview() {
+    SatsTheme {
+        SatsSurface {
+            SessionDetailsInfoSection(
+                durationLabel = { SessionDetailsInfoLabelPlaceholder("60 min") },
+                dateLabel = { SessionDetailsInfoLabelPlaceholder("Sat, Dec 2 2:30 PM") },
+                locationLabel = { SessionDetailsInfoLabelPlaceholder("SATS Bergen LHG") },
+                workoutTypeLabel = { SessionDetailsInfoLabelPlaceholder("Strength Training") },
+                gxNameLabel = { SessionDetailsInfoLabelPlaceholder("Pure Strength") },
             )
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
@@ -112,7 +112,7 @@ fun SessionDetailsInfoLabel(
 }
 
 @Composable
-fun SessionDetailsSectionPlaceholder(
+fun SessionDetailsInfoSectionPlaceholder(
     modifier: Modifier = Modifier,
     showDurationLabel: Boolean = true,
     showDateLabel: Boolean = true,
@@ -209,7 +209,7 @@ private fun SessionDetailsInfoSectionPreview() {
 private fun SessionDetailsInfoSectionPlaceholderPreview() {
     SatsTheme {
         SatsSurface {
-            SessionDetailsSectionPlaceholder()
+            SessionDetailsInfoSectionPlaceholder()
         }
     }
 }


### PR DESCRIPTION
Add a `SessionDetailsInfoLabelPlaceholder` that can be used instead of a `SessionDetailsInfoLabel` to signal that content is loading. To make sure that this takes up as much space as the non-placeholder variant, the non-placeholder variant now doesn't change height depending on whether it's clickable or not. That means that there is now more padding between items that are non-clickable, which might not be exactly what I want.

I've also added Material 3 support by using `MaterialText` and `MaterialIcon` internally, which chooses the correct one based on `LocalUseMaterial3.current`.

|   |   |
| - | - |
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/3b83e1a4-57e8-42ee-8ecf-512540bab832) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/5c5fb531-a550-4d20-8d07-4ec893a656df) |
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/0e3ae33e-a7e4-4364-a511-17b3de97629b) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/9ed684f6-9014-48c5-aa9a-80f4daeb2c08) |
