### PR TITLE
NMA-5945: Default SatsEmptyState to no background

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/EmptyStateSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/EmptyStateSampleScreen.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.sats.dna.components.SatsEmptyState
 import com.sats.dna.components.SatsEmptyStateAction
+import com.sats.dna.components.SatsEmptyStateCard
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
@@ -31,7 +31,7 @@ private fun EmptyStateScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            SatsEmptyState(
+            SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
                 body = "If you make friends, you can follow in their working out and stuff. " +
@@ -40,7 +40,7 @@ private fun EmptyStateScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
                 modifier = Modifier,
             )
 
-            SatsEmptyState(
+            SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
                 body = null,
@@ -48,7 +48,7 @@ private fun EmptyStateScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            SatsEmptyState(
+            SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
                 body = "If you make friends, you can follow in their working out and stuff. " +
@@ -57,7 +57,7 @@ private fun EmptyStateScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
                 modifier = Modifier,
             )
 
-            SatsEmptyState(
+            SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
                 body = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
@@ -19,6 +19,29 @@ import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
+@Composable
+fun SatsEmptyStateCard(
+    icon: Painter,
+    title: String,
+    body: String?,
+    action: SatsEmptyStateAction?,
+    modifier: Modifier = Modifier,
+) {
+    CompositionLocalProvider(LocalUseMaterial3 provides true) {
+        SatsCard(modifier) {
+            SatsEmptyState(
+                icon = icon,
+                title = title,
+                body = body,
+                action = action,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}
+
 /**
  * A card that signals to the member that something is missing. Note that this is not the same as an error. Instead,
  * this component should be used as a placeholder for when we would like to display some data, but there is no data to
@@ -42,35 +65,31 @@ fun SatsEmptyState(
     modifier: Modifier = Modifier,
 ) {
     CompositionLocalProvider(LocalUseMaterial3 provides true) {
-        SatsCard(modifier) {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            MaterialIcon(icon, contentDescription = null, Modifier.size(18.dp))
+
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(SatsTheme.spacing.m),
-                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                MaterialIcon(icon, contentDescription = null, Modifier.size(18.dp))
+                MaterialText(title, textAlign = TextAlign.Center)
 
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    MaterialText(title, textAlign = TextAlign.Center)
-
-                    if (body != null) {
-                        MaterialText(
-                            text = body,
-                            color = SatsTheme.colors2.surfaces.primary.fg.alternate,
-                            textAlign = TextAlign.Center,
-                            style = SatsTheme.typography.normal.small,
-                        )
-                    }
+                if (body != null) {
+                    MaterialText(
+                        text = body,
+                        color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+                        textAlign = TextAlign.Center,
+                        style = SatsTheme.typography.normal.small,
+                    )
                 }
+            }
 
-                if (action != null) {
-                    SatsButton(action.action, action.label)
-                }
+            if (action != null) {
+                SatsButton(action.action, action.label)
             }
         }
     }
@@ -90,6 +109,23 @@ private fun SatsEmptyStatePreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             SatsEmptyState(
+                icon = SatsTheme.icons.barbell,
+                title = "You don't have friends",
+                body = "If you make friends, you can follow in their working out and stuff. " +
+                    "And they can follow whatever you're doing, as well!",
+                action = SatsEmptyStateAction(action = {}, "Make friends"),
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SatsEmptyStateCardPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
                 body = "If you make friends, you can follow in their working out and stuff. " +


### PR DESCRIPTION
This changes `SatsEmptyState` to no longer be wrapped in a `SatsCard` by default, but rather have no background color. Its layout is still exactly the same. A new `SatsEmptyStateCard` is introduced that replicates the behaviour from before.
