### PR TITLE
NMA-6012: Fix default content color for SatsBanner in dark mode

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.sats.dna.colors.satsContentColorFor
+import com.sats.dna.colors.satsContentColor2For
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.internal.MaterialText
@@ -21,7 +21,7 @@ fun SatsBanner(
     modifier: Modifier = Modifier,
     action: @Composable (() -> Unit)? = null,
     backgroundColor: Color = SatsTheme.colors2.backgrounds.fixed.bg.default,
-    contentColor: Color = satsContentColorFor(backgroundColor),
+    contentColor: Color = satsContentColor2For(backgroundColor),
 ) {
     SatsSurface(
         modifier = modifier,


### PR DESCRIPTION
## Before

![image](https://github.com/sats-group/sats-dna-android/assets/386122/496e15e5-f1f4-49c4-bad7-ab5fe73e99ad)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/6d7f54da-38b2-4062-b774-ece98623b259)

## After

![image](https://github.com/sats-group/sats-dna-android/assets/386122/cd4b1013-b2ca-4ad2-a08a-fed7d439208b)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/c6596544-ad42-41dc-9352-07b69dbcb192)
