### PR TITLE
NMA-6069: Fix colors for `SatsCard` when in Material 3

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CardSampleScreen.kt
@@ -1,9 +1,9 @@
 package com.sats.dna.sample.screens
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +15,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
@@ -39,23 +41,23 @@ private fun SatsCardScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
         ) {
             SatsCard {
                 Column(Modifier.clickable { }) {
-                    Box(
-                        Modifier
+                    Image(
+                        painterResource(com.sats.dna.R.drawable.debug_img_placeholder),
+                        contentDescription = null,
+                        modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(16f / 9)
                             .background(SatsTheme.colors2.surfaces.fixed.bg.default),
-                    ) {
-                        Text(
-                            text = "Image",
-                            modifier = Modifier.align(Alignment.Center),
-                            color = SatsTheme.colors2.surfaces.fixed.fg.default,
-                        )
-                    }
+                        contentScale = ContentScale.Crop,
+                    )
 
                     Column(Modifier.padding(SatsTheme.spacing.m), Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                        Text("Material 3 Card", style = SatsTheme.typography.medium.large)
+                        Text("SATS Card", style = SatsTheme.typography.medium.large)
 
-                        Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+                        Text(
+                            "This is a SATS Card with an image, a title and a body text. It is not limited to these " +
+                                "fields, nor are any of them required; this is just one way it can be presented.",
+                        )
                     }
                 }
             }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -28,17 +26,13 @@ fun SatsCard(
     content: @Composable () -> Unit,
 ) {
     if (LocalUseMaterial3.current) {
-        ElevatedCard(
+        SatsSurface(
             modifier = modifier,
+            color = SatsTheme.colors2.surfaces.primary.bg.default,
             shape = SatsTheme.shapes.roundedCorners.small,
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = SatsTheme.colors2.surfaces.primary.bg.default,
-                contentColor = SatsTheme.colors2.surfaces.primary.fg.default,
-            ),
-            elevation = CardDefaults.elevatedCardElevation(1.dp),
-        ) {
-            content()
-        }
+            elevation = 1.dp,
+            content = content,
+        )
     } else {
         M2Card(
             modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -18,30 +18,19 @@ import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
-import androidx.compose.material.Card as M2Card
 
 @Composable
 fun SatsCard(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    if (LocalUseMaterial3.current) {
-        SatsSurface(
-            modifier = modifier,
-            color = SatsTheme.colors2.surfaces.primary.bg.default,
-            shape = SatsTheme.shapes.roundedCorners.small,
-            elevation = 1.dp,
-            content = content,
-        )
-    } else {
-        M2Card(
-            modifier = modifier,
-            shape = SatsTheme.shapes.roundedCorners.small,
-            backgroundColor = SatsTheme.colors2.surfaces.primary.bg.default,
-            contentColor = SatsTheme.colors2.surfaces.primary.fg.default,
-            content = content,
-        )
-    }
+    SatsSurface(
+        modifier = modifier,
+        color = SatsTheme.colors2.surfaces.primary.bg.default,
+        shape = SatsTheme.shapes.roundedCorners.small,
+        elevation = 1.dp,
+        content = content,
+    )
 }
 
 @LightDarkPreview


### PR DESCRIPTION
Create `SatsCard` from scratch using only a `SatsSurface` with some elevation. This fixes a color issue with the Material 3 (`ElevactedCard`-backed) cards, where a tonal elevation was applied automatically, and also just aligns Material 2 and Material 3 cards to look exactly the same.

## Screenshots

| | |
|-|-|
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/b56f0015-4b96-4d3a-9095-107e9b3610a0) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/6799bb0c-3870-48c6-b00d-338d2f8fddd7) |