### PR TITLE
NMA-6073: Fix button clipping on large font scales

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -1,16 +1,17 @@
 package com.sats.dna.sample.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -48,6 +49,7 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
         Column(
             Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(innerPadding)
                 .padding(vertical = SatsTheme.spacing.m),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -137,12 +139,12 @@ private class ControlPanelState {
 }
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 private fun ControlPanel(state: ControlPanelState) {
     SatsSurface(Modifier.fillMaxWidth(), elevation = 2.dp) {
-        FlowRow(
+        Row(
             Modifier
                 .navigationBarsPadding()
+                .horizontalScroll(rememberScrollState())
                 .padding(SatsTheme.spacing.m),
             horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
         ) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -6,11 +6,9 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -24,11 +22,13 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.FontSizePreview
 import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
@@ -71,7 +71,9 @@ fun SatsButton(
         colors = buttonColors,
         contentPadding = buttonPadding(isLarge),
     ) {
-        Row(Modifier.height(24.dp), verticalAlignment = CenterVertically) {
+        // Note that a horizontal arrangement is not used for spacing items, as a space-aligned arrangement would
+        // still put space between the AnimatedContent and the text, even if the AnimatedContent is empty.
+        Row(verticalAlignment = CenterVertically) {
             AnimatedContent(iconContent, label = "Animated icon content") { iconContent ->
                 when (iconContent) {
                     is IconContent.Empty -> Unit
@@ -100,13 +102,7 @@ fun SatsButton(
                 }
             }
 
-            Text(
-                text = label,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .wrapContentHeight(),
-                maxLines = 1,
-            )
+            Text(label, maxLines = 1)
         }
     }
 }
@@ -129,19 +125,38 @@ private fun buttonPadding(isLarge: Boolean): PaddingValues {
 
 @LightDarkPreview
 @Composable
-private fun Preview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
+private fun SatsButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 SatsButton(onClick = {}, color.name, Modifier.padding(SatsTheme.spacing.s), color)
                 SatsButton(
                     onClick = {},
-                    "${color.name} disabled",
-                    Modifier.padding(SatsTheme.spacing.s),
-                    color,
+                    label = "${color.name} disabled",
+                    modifier = Modifier.padding(SatsTheme.spacing.s),
+                    colors = color,
                     isEnabled = false,
+                )
+            }
+        }
+    }
+}
+
+@FontSizePreview
+@Composable
+private fun SatsButtonFontScalePreview() {
+    SatsTheme {
+        SatsSurface(
+            modifier = Modifier.fillMaxWidth(),
+            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            useMaterial3 = true,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                SatsButton(
+                    onClick = {},
+                    label = "${LocalConfiguration.current.fontScale}x",
+                    modifier = Modifier.padding(SatsTheme.spacing.s),
+                    colors = SatsButtonColor.Primary,
                 )
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
@@ -9,5 +9,5 @@ annotation class LightDarkPreview
 
 @Preview("Small Font Size (0.75x)", group = "Font Sizes", fontScale = 0.75f)
 @Preview("Large Font Size (1.50x)", group = "Font Sizes", fontScale = 1.5f)
-@Preview("Huge Font Size (3.0x)", group = "Font Sizes", fontScale = 3f)
+@Preview("Huge Font Size (2.0x)", group = "Font Sizes", fontScale = 2f)
 annotation class FontSizePreview

--- a/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview("Dark Mode", group = "Theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 annotation class LightDarkPreview
 
-@Preview("Small Font Size", group = "Font Sizes", fontScale = 0.75f)
-@Preview("Large Font Size", group = "Font Sizes", fontScale = 1.50f)
+@Preview("Small Font Size (0.75x)", group = "Font Sizes", fontScale = 0.75f)
+@Preview("Large Font Size (1.50x)", group = "Font Sizes", fontScale = 1.5f)
+@Preview("Huge Font Size (3.0x)", group = "Font Sizes", fontScale = 3f)
 annotation class FontSizePreview


### PR DESCRIPTION
# Screenshots

## Before

![image](https://github.com/sats-group/sats-dna-android/assets/386122/1f8675bc-093c-4a60-bc20-53bfdc0308ae)

## After

### Small Font Size (0.75x)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/cf145352-75c3-4516-9d52-d5d434434e0c)

### Large Font Size (1.50x)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/ba8621d4-d7f6-49d0-a80d-c758a43416e7)

### Huge Font Size (3.0x)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/e77002da-dc1e-4502-9a57-8f35a1bc4608)
