### PR TITLE
NMA-6119: Make some opinionated changes to the snackbar

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SnackbarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SnackbarSampleScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,6 +28,7 @@ private fun SnackbarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
     ComponentScreen("Snackbar", navigateUp, modifier) { innerPadding ->
         Column(
             Modifier
+                .verticalScroll(rememberScrollState())
                 .padding(innerPadding)
                 .padding(SatsTheme.spacing.m)
                 .fillMaxSize()
@@ -41,28 +44,35 @@ private fun SnackbarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
             SatsSnackbar("Oops, that didn't work at all! You should probably talk to the manager.", action)
 
             SatsSnackbar(
-                "Oops, that didn't work at all! And this message is way too long for the entire text to be seen. " +
-                    "We might want to reconsider those texts.",
-                action,
+                message = "Oops, that didn't work at all! " +
+                    "And this message is way too long for the entire text to be seen. " +
+                    "We might want to reconsider those texts. Texts that span more than " +
+                    "three lines will be cut off, so don't do that.",
+                action = action,
             )
+
             SatsSnackbar(
                 visuals = SatsSnackbarDefaults.snackbarVisuals(
                     title = "Something went wrong.",
                     message = "Oops, that didn't work at all! " +
                         "And this message is way too long for the entire text to be seen. " +
-                        "We might want to reconsider those texts.",
+                        "We might want to reconsider those texts. Texts that span more than " +
+                        "three lines will be cut off, so don't do that.",
                     action = action,
                 ),
 
             )
+
             SatsSnackbar(
                 visuals = SatsSnackbarDefaults.snackbarVisuals(
-                    title = "Yay!",
-                    message = "You did so well on that workout. Book another one!",
+                    title = "Yay! Invitations have been sent!",
+                    message = "You can always add or remove friends later, or change other details.",
+                    action = null,
                     theme = SatsSnackbarTheme.Success,
                     dismissAction = SatsSnackbarAction({}, "close"),
                 ),
             )
+
             SatsSnackbar(
                 visuals = SatsSnackbarDefaults.snackbarVisuals(
                     message = "Workout created!",

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TypographySampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TypographySampleScreen.kt
@@ -1,5 +1,6 @@
 package com.sats.dna.sample.screens
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -48,58 +49,58 @@ private fun TypographyScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.l),
         ) {
             Section("NORMAL") {
-                TextSample2("Headline 1", SatsTheme.typography.normal.headline1)
-                TextSample2("Headline 2", SatsTheme.typography.normal.headline2)
-                TextSample2("Headline 3", SatsTheme.typography.normal.headline3)
-                TextSample2("Large", SatsTheme.typography.normal.large)
-                TextSample2("Basic", SatsTheme.typography.normal.basic)
-                TextSample2("Small", SatsTheme.typography.normal.small)
-                TextSample2("Button", SatsTheme.typography.normal.button)
-                TextSample2("Section", SatsTheme.typography.normal.section)
+                TextSample("Headline 1", SatsTheme.typography.normal.headline1)
+                TextSample("Headline 2", SatsTheme.typography.normal.headline2)
+                TextSample("Headline 3", SatsTheme.typography.normal.headline3)
+                TextSample("Large", SatsTheme.typography.normal.large)
+                TextSample("Basic", SatsTheme.typography.normal.basic)
+                TextSample("Small", SatsTheme.typography.normal.small)
+                TextSample("Button", SatsTheme.typography.normal.button)
+                TextSample("Section", SatsTheme.typography.normal.section)
             }
 
             SatsHorizontalDivider()
 
             Section("MEDIUM") {
-                TextSample2("Headline 1", SatsTheme.typography.medium.headline1)
-                TextSample2("Headline 2", SatsTheme.typography.medium.headline2)
-                TextSample2("Headline 3", SatsTheme.typography.medium.headline3)
-                TextSample2("Large", SatsTheme.typography.medium.large)
-                TextSample2("Basic", SatsTheme.typography.medium.basic)
-                TextSample2("Small", SatsTheme.typography.medium.small)
+                TextSample("Headline 1", SatsTheme.typography.medium.headline1)
+                TextSample("Headline 2", SatsTheme.typography.medium.headline2)
+                TextSample("Headline 3", SatsTheme.typography.medium.headline3)
+                TextSample("Large", SatsTheme.typography.medium.large)
+                TextSample("Basic", SatsTheme.typography.medium.basic)
+                TextSample("Small", SatsTheme.typography.medium.small)
             }
 
             SatsHorizontalDivider()
 
             Section("EMPHASIS") {
-                TextSample2("Headline 1", SatsTheme.typography.emphasis.headline1)
-                TextSample2("Headline 2", SatsTheme.typography.emphasis.headline2)
-                TextSample2("Headline 3", SatsTheme.typography.emphasis.headline3)
-                TextSample2("Large", SatsTheme.typography.emphasis.large)
-                TextSample2("Basic", SatsTheme.typography.emphasis.basic)
-                TextSample2("Small", SatsTheme.typography.emphasis.small)
+                TextSample("Headline 1", SatsTheme.typography.emphasis.headline1)
+                TextSample("Headline 2", SatsTheme.typography.emphasis.headline2)
+                TextSample("Headline 3", SatsTheme.typography.emphasis.headline3)
+                TextSample("Large", SatsTheme.typography.emphasis.large)
+                TextSample("Basic", SatsTheme.typography.emphasis.basic)
+                TextSample("Small", SatsTheme.typography.emphasis.small)
             }
 
             SatsHorizontalDivider()
 
             Section("SATS HEADLINE – NORMAL") {
-                TextSample2("Headline 1", SatsTheme.typography.satsHeadlineNormal.headline1)
-                TextSample2("Headline 2", SatsTheme.typography.satsHeadlineNormal.headline2)
-                TextSample2("Headline 3", SatsTheme.typography.satsHeadlineNormal.headline3)
-                TextSample2("Large", SatsTheme.typography.satsHeadlineNormal.large)
-                TextSample2("Basic", SatsTheme.typography.satsHeadlineNormal.basic)
-                TextSample2("Small", SatsTheme.typography.satsHeadlineNormal.small)
+                TextSample("Headline 1", SatsTheme.typography.satsHeadlineNormal.headline1)
+                TextSample("Headline 2", SatsTheme.typography.satsHeadlineNormal.headline2)
+                TextSample("Headline 3", SatsTheme.typography.satsHeadlineNormal.headline3)
+                TextSample("Large", SatsTheme.typography.satsHeadlineNormal.large)
+                TextSample("Basic", SatsTheme.typography.satsHeadlineNormal.basic)
+                TextSample("Small", SatsTheme.typography.satsHeadlineNormal.small)
             }
 
             SatsHorizontalDivider()
 
             Section("SATS HEADLINE – EMPHASIS") {
-                TextSample2("Headline 1", SatsTheme.typography.satsHeadlineEmphasis.headline1)
-                TextSample2("Headline 2", SatsTheme.typography.satsHeadlineEmphasis.headline2)
-                TextSample2("Headline 3", SatsTheme.typography.satsHeadlineEmphasis.headline3)
-                TextSample2("Large", SatsTheme.typography.satsHeadlineEmphasis.large)
-                TextSample2("Basic", SatsTheme.typography.satsHeadlineEmphasis.basic)
-                TextSample2("Small", SatsTheme.typography.satsHeadlineEmphasis.small)
+                TextSample("Headline 1", SatsTheme.typography.satsHeadlineEmphasis.headline1)
+                TextSample("Headline 2", SatsTheme.typography.satsHeadlineEmphasis.headline2)
+                TextSample("Headline 3", SatsTheme.typography.satsHeadlineEmphasis.headline3)
+                TextSample("Large", SatsTheme.typography.satsHeadlineEmphasis.large)
+                TextSample("Basic", SatsTheme.typography.satsHeadlineEmphasis.basic)
+                TextSample("Small", SatsTheme.typography.satsHeadlineEmphasis.small)
             }
         }
     }
@@ -108,7 +109,7 @@ private fun TypographyScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
 @Composable
 private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m)) {
-        Text(title, style = SatsTheme.typography.emphasis.basic)
+        Text(title, style = SatsTheme.typography.satsHeadlineEmphasis.basic)
 
         Column(verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)) {
             content()
@@ -117,7 +118,7 @@ private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) 
 }
 
 @Composable
-private fun TextSample2(text: String, style: TextStyle) {
+private fun TextSample(text: String, style: TextStyle) {
     Column {
         var isExpanded by rememberSaveable { mutableStateOf(false) }
 
@@ -126,13 +127,15 @@ private fun TextSample2(text: String, style: TextStyle) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(text, style = style)
+            Text(text, Modifier.weight(1f), style = style)
 
             IconToggleButton(checked = isExpanded, onCheckedChange = { isExpanded = it }) {
-                if (isExpanded) {
-                    Icon(SatsTheme.icons.arrowUp, contentDescription = null)
-                } else {
-                    Icon(SatsTheme.icons.arrowDown, contentDescription = null)
+                AnimatedContent(isExpanded, label = "expand-icon") {
+                    if (it) {
+                        Icon(SatsTheme.icons.arrowUp, contentDescription = null)
+                    } else {
+                        Icon(SatsTheme.icons.arrowDown, contentDescription = null)
+                    }
                 }
             }
         }
@@ -145,6 +148,7 @@ private fun TextSample2(text: String, style: TextStyle) {
                     Text("Weight: ${style.fontWeight?.weight}")
                     Text("Style: ${style.fontStyle}")
                     Text("Size: ${style.fontSize}")
+                    Text("Baseline shift: ${style.baselineShift?.multiplier ?: 0f}")
                 }
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
@@ -1,28 +1,27 @@
 package com.sats.dna.components.snackbar
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.CenterVertically
-import androidx.compose.ui.Alignment.Companion.Top
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.components.button.SatsIconButton
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
+import com.sats.dna.tooling.FontSizePreview
 import com.sats.dna.tooling.LightDarkPreview
 
 /**
@@ -32,8 +31,7 @@ import com.sats.dna.tooling.LightDarkPreview
  * @param action Optional action to be shown as a button in the snackbar.
  * @param modifier The modifier to be applied to this composable.
  * @param theme Theme for the snackbar, by default [SatsSnackbarTheme.Info].
- *
- * **/
+ */
 @Composable
 fun SatsSnackbar(
     message: String,
@@ -58,77 +56,107 @@ fun SatsSnackbar(
  * @param modifier The modifier to be applied to this composable.
  *
  * @see [SatsSnackbarDefaults]
- * **/
-
+ */
 @Composable
 fun SatsSnackbar(
     visuals: SatsSnackbarVisuals,
     modifier: Modifier = Modifier,
 ) {
     SatsSurface(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min),
+        modifier = modifier.fillMaxWidth(),
         shape = SatsTheme.shapes.roundedCorners.small,
         elevation = 6.dp,
         color = visuals.colors.containerColor,
         contentColor = visuals.colors.contentColor,
     ) {
-        Row(
-            Modifier
-                .padding(SatsTheme.spacing.m)
-                .fillMaxHeight(),
-            horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
-            verticalAlignment = if (visuals.title == null) CenterVertically else Top,
-        ) {
-            visuals.leadingIcon()
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
-                verticalAlignment = CenterVertically,
-            ) {
-                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                    visuals.title?.let { title ->
-                        MaterialText(
-                            text = title,
-                            style = SatsTheme.typography.emphasis.basic,
-                            color = visuals.colors.titleColor,
+        Column {
+            Row(horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)) {
+                Row(
+                    modifier = Modifier
+                        .padding(
+                            start = SatsTheme.spacing.s,
+                            top = SatsTheme.spacing.s,
+                            end = if (visuals.dismissAction == null) SatsTheme.spacing.s else 0.dp,
+                            bottom = if (visuals.action == null) SatsTheme.spacing.s else 0.dp,
                         )
-                    }
+                        .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
+                ) {
+                    LeadingIcon(visuals.leadingIcon)
 
-                    MaterialText(
-                        text = visuals.message,
-                        maxLines = 3,
-                        overflow = Ellipsis,
-                    )
-                }
-
-                if (visuals.action != null) {
-                    SatsButton(visuals.action.action, visuals.action.label, colors = SatsButtonColor.Transparent)
+                    TitleAndMessage(visuals, Modifier.weight(1f))
                 }
 
                 if (visuals.dismissAction != null) {
-                    IconButton(
+                    SatsIconButton(
                         onClick = visuals.dismissAction.action,
-                        modifier = Modifier
-                            .align(Top)
-                            .offset(x = SatsTheme.spacing.m, y = -SatsTheme.spacing.m),
-                    ) {
-                        MaterialIcon(
-                            modifier = Modifier.size(20.dp),
-                            painter = SatsTheme.icons.close,
-                            contentDescription = visuals.dismissAction.label,
-                        )
-                    }
+                        icon = SatsTheme.icons.close,
+                        onClickLabel = visuals.dismissAction.label,
+                        modifier = Modifier.align(Alignment.Top),
+                        colors = SatsButtonColor.Secondary,
+                    )
                 }
+            }
+
+            if (visuals.action != null) {
+                ActionButton(
+                    action = visuals.action,
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(end = SatsTheme.spacing.xxs),
+                )
             }
         }
     }
 }
 
+@Composable
+private fun LeadingIcon(leadingIcon: SatsSnackbarLeadingIcon, modifier: Modifier = Modifier) {
+    Box(modifier) {
+        when (leadingIcon) {
+            is SatsSnackbarLeadingIcon.Emoji -> {
+                MaterialText(leadingIcon.text, Modifier.clearAndSetSemantics { })
+            }
+
+            is SatsSnackbarLeadingIcon.Icon -> {
+                MaterialIcon(leadingIcon.painter, contentDescription = null, Modifier.size(18.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TitleAndMessage(visuals: SatsSnackbarVisuals, modifier: Modifier = Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
+        if (visuals.title != null) {
+            MaterialText(
+                text = visuals.title,
+                style = SatsTheme.typography.emphasis.basic,
+                color = visuals.colors.titleColor,
+            )
+        }
+
+        MaterialText(
+            text = visuals.message,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun ActionButton(action: SatsSnackbarAction, modifier: Modifier = Modifier) {
+    SatsButton(
+        onClick = action.action,
+        label = action.label,
+        modifier = modifier,
+        colors = SatsButtonColor.Transparent,
+    )
+}
+
 @LightDarkPreview
 @Composable
-private fun SnackbarPreview() {
+private fun RegularSnackbarPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             val message = "Something went wrong. You should probably try that one more time."
@@ -141,7 +169,7 @@ private fun SnackbarPreview() {
 
 @LightDarkPreview
 @Composable
-private fun SnackBarVisualsPreview() {
+private fun SuccessSnackbarPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             val snackbarVisuals = SatsSnackbarDefaults.snackbarVisuals(
@@ -151,6 +179,61 @@ private fun SnackBarVisualsPreview() {
                 theme = SatsSnackbarTheme.Success,
                 dismissAction = SatsSnackbarAction({}, "close"),
             )
+
+            SatsSnackbar(snackbarVisuals, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SnackbarWithActionPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            val snackbarVisuals = SatsSnackbarDefaults.snackbarVisuals(
+                title = "Yay! Invitations have been sent!",
+                message = "You can always add or remove friends later, or change other details.",
+                action = SatsSnackbarAction(action = {}, label = "Try again"),
+                theme = SatsSnackbarTheme.Info,
+                dismissAction = null,
+            )
+
+            SatsSnackbar(snackbarVisuals, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SnackbarWithDismissAndActionPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            val snackbarVisuals = SatsSnackbarDefaults.snackbarVisuals(
+                title = "Yay! Invitations have been sent!",
+                message = "You can always add or remove friends later, or change other details.",
+                action = SatsSnackbarAction(action = {}, label = "Try again"),
+                theme = SatsSnackbarTheme.Info,
+                dismissAction = SatsSnackbarAction({}, "close"),
+            )
+
+            SatsSnackbar(snackbarVisuals, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}
+
+@FontSizePreview
+@Composable
+private fun SnackbarFontSizesPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            val snackbarVisuals = SatsSnackbarDefaults.snackbarVisuals(
+                title = "Yay! Invitations have been sent!",
+                message = "You can always add or remove friends later, or change other details.",
+                action = SatsSnackbarAction(action = {}, label = "Try again"),
+                theme = SatsSnackbarTheme.Info,
+                dismissAction = SatsSnackbarAction({}, "close"),
+            )
+
             SatsSnackbar(snackbarVisuals, Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
@@ -87,7 +87,7 @@ fun SatsSnackbar(
                 horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
                 verticalAlignment = CenterVertically,
             ) {
-                Column(Modifier.weight(1f)) {
+                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
                     visuals.title?.let {
                         Text(
                             text = it,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.Top
@@ -66,14 +65,14 @@ fun SatsSnackbar(
     visuals: SatsSnackbarVisuals,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    SatsSurface(
         modifier = modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min),
         shape = SatsTheme.shapes.roundedCorners.small,
-        shadowElevation = 6.dp,
-        color = visuals.colors.backgroundColor,
-        contentColor = visuals.colors.containerColor,
+        elevation = 6.dp,
+        color = visuals.colors.containerColor,
+        contentColor = visuals.colors.contentColor,
     ) {
         Row(
             Modifier

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
@@ -82,6 +83,7 @@ fun SatsSnackbar(
             verticalAlignment = if (visuals.title == null) CenterVertically else Top,
         ) {
             visuals.leadingIcon()
+
             Row(
                 horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
                 verticalAlignment = CenterVertically,
@@ -105,11 +107,15 @@ fun SatsSnackbar(
                 if (visuals.action != null) {
                     SatsButton(visuals.action.action, visuals.action.label, colors = SatsButtonColor.Transparent)
                 }
+
                 if (visuals.dismissAction != null) {
                     IconButton(
                         onClick = visuals.dismissAction.action,
+                        modifier = Modifier
+                            .align(Top)
+                            .offset(x = SatsTheme.spacing.m, y = -SatsTheme.spacing.m),
                     ) {
-                        Icon(
+                        MaterialIcon(
                             modifier = Modifier.size(20.dp),
                             painter = SatsTheme.icons.close,
                             contentDescription = visuals.dismissAction.label,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbar.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.Top
@@ -88,15 +87,16 @@ fun SatsSnackbar(
                 verticalAlignment = CenterVertically,
             ) {
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs)) {
-                    visuals.title?.let {
-                        Text(
-                            text = it,
-                            style = SatsTheme.typography.normal.basic,
+                    visuals.title?.let { title ->
+                        MaterialText(
+                            text = title,
+                            style = SatsTheme.typography.emphasis.basic,
                             color = visuals.colors.titleColor,
                         )
                     }
+
                     MaterialText(
-                        visuals.message,
+                        text = visuals.message,
                         maxLines = 3,
                         overflow = Ellipsis,
                     )

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbarVisuals.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbarVisuals.kt
@@ -2,16 +2,18 @@ package com.sats.dna.components.snackbar
 
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarVisuals
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import com.sats.dna.internal.MaterialIcon
+import androidx.compose.ui.graphics.painter.Painter
 import com.sats.dna.theme.SatsTheme
 
+sealed interface SatsSnackbarLeadingIcon {
+    class Icon(val painter: Painter) : SatsSnackbarLeadingIcon
+    class Emoji(val text: String) : SatsSnackbarLeadingIcon
+}
+
 class SatsSnackbarVisuals internal constructor(
-    val leadingIcon: @Composable () -> Unit,
+    val leadingIcon: SatsSnackbarLeadingIcon,
     val title: String?,
     override val message: String,
     val action: SatsSnackbarAction?,
@@ -19,7 +21,6 @@ class SatsSnackbarVisuals internal constructor(
     override val duration: SnackbarDuration,
     val colors: SatsSnackbarColors,
 ) : SnackbarVisuals {
-
     override val actionLabel: String? = action?.label
     override val withDismissAction: Boolean = dismissAction != null
 }
@@ -38,7 +39,6 @@ class SatsSnackbarColors internal constructor(
 )
 
 object SatsSnackbarDefaults {
-
     /**
      * Creates snackbar visuals for a sats snackbar.
      *
@@ -49,7 +49,7 @@ object SatsSnackbarDefaults {
      * will become the content description for the dismiss icon.
      * @param duration How long the snackbar will be shown.
      * @param theme The snackbar theme, this will determine the snackbar colors and icon.
-     * **/
+     */
     @Composable
     fun snackbarVisuals(
         message: String,
@@ -64,7 +64,7 @@ object SatsSnackbarDefaults {
             duration = duration,
             message = message,
             dismissAction = dismissAction,
-            leadingIcon = { theme.LeadingIcon() },
+            leadingIcon = theme.leadingIcon(),
             title = title,
             colors = theme.getSnackBarColors(),
         )
@@ -85,16 +85,8 @@ object SatsSnackbarDefaults {
     }
 
     @Composable
-    private fun SatsSnackbarTheme.LeadingIcon() = when (this) {
-        SatsSnackbarTheme.Info -> {
-            MaterialIcon(SatsTheme.icons.info, contentDescription = null)
-        }
-
-        SatsSnackbarTheme.Success -> {
-            Text(
-                text = "🎉",
-                modifier = Modifier.clearAndSetSemantics {},
-            )
-        }
+    private fun SatsSnackbarTheme.leadingIcon(): SatsSnackbarLeadingIcon = when (this) {
+        SatsSnackbarTheme.Info -> SatsSnackbarLeadingIcon.Icon(SatsTheme.icons.info)
+        SatsSnackbarTheme.Success -> SatsSnackbarLeadingIcon.Emoji("🎉")
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbarVisuals.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/snackbar/SatsSnackbarVisuals.kt
@@ -32,8 +32,8 @@ enum class SatsSnackbarTheme {
 class SatsSnackbarAction(val action: () -> Unit, val label: String)
 
 class SatsSnackbarColors internal constructor(
-    val backgroundColor: Color,
     val containerColor: Color,
+    val contentColor: Color,
     val titleColor: Color,
 )
 
@@ -72,14 +72,14 @@ object SatsSnackbarDefaults {
     @Composable
     fun SatsSnackbarTheme.getSnackBarColors(): SatsSnackbarColors = when (this) {
         SatsSnackbarTheme.Info -> SatsSnackbarColors(
-            backgroundColor = SatsTheme.colors2.surfaces.primary.bg.default,
-            containerColor = SatsTheme.colors2.surfaces.primary.fg.default,
+            containerColor = SatsTheme.colors2.surfaces.primary.bg.default,
+            contentColor = SatsTheme.colors2.surfaces.primary.fg.default,
             titleColor = SatsTheme.colors2.surfaces.primary.fg.alternate,
         )
 
         SatsSnackbarTheme.Success -> SatsSnackbarColors(
-            backgroundColor = SatsTheme.colors2.signalSurfaces.success.bg,
-            containerColor = SatsTheme.colors2.signalSurfaces.success.fg.default,
+            containerColor = SatsTheme.colors2.signalSurfaces.success.bg,
+            contentColor = SatsTheme.colors2.signalSurfaces.success.fg.default,
             titleColor = SatsTheme.colors2.signalSurfaces.success.fg.alternate,
         )
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/typography/SatsTypography.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/typography/SatsTypography.kt
@@ -3,6 +3,7 @@ package com.sats.dna.typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.unit.sp
 import com.sats.fonts.headline.SatsHeadlineFont
 
@@ -68,12 +69,12 @@ private object NormalTextStylesApp : NormalTextStyles {
         fontStyle = FontStyle.Normal,
     )
 
-    override val headline1 = base.copy(fontSize = Sizes.headline1)
-    override val headline2 = base.copy(fontSize = Sizes.headline2)
-    override val headline3 = base.copy(fontSize = Sizes.headline3)
-    override val large = base.copy(fontSize = Sizes.large)
-    override val basic = base.copy(fontSize = Sizes.basic)
-    override val small = base.copy(fontSize = Sizes.small)
+    override val headline1 = base.copy(fontSize = Sizes.headline1, baselineShift = BaselineShift(.32f))
+    override val headline2 = base.copy(fontSize = Sizes.headline2, baselineShift = BaselineShift(.51f))
+    override val headline3 = base.copy(fontSize = Sizes.headline3, baselineShift = BaselineShift(.51f))
+    override val large = base.copy(fontSize = Sizes.large, baselineShift = BaselineShift(.3f))
+    override val basic = base.copy(fontSize = Sizes.basic, baselineShift = BaselineShift(.3f))
+    override val small = base.copy(fontSize = Sizes.small, baselineShift = BaselineShift(.3f))
     override val button = base.copy(fontSize = Sizes.button, fontWeight = FontWeight.SemiBold)
     override val section = base.copy(fontSize = Sizes.section, fontWeight = FontWeight.SemiBold)
 }
@@ -85,12 +86,12 @@ private object MediumTextStylesApp : MediumTextStyles {
         fontStyle = FontStyle.Normal,
     )
 
-    override val headline1 = base.copy(fontSize = Sizes.headline1)
-    override val headline2 = base.copy(fontSize = Sizes.headline2)
-    override val headline3 = base.copy(fontSize = Sizes.headline3)
-    override val large = base.copy(fontSize = Sizes.large)
-    override val basic = base.copy(fontSize = Sizes.basic)
-    override val small = base.copy(fontSize = Sizes.small)
+    override val headline1 = base.copy(fontSize = Sizes.headline1, baselineShift = BaselineShift(.32f))
+    override val headline2 = base.copy(fontSize = Sizes.headline2, baselineShift = BaselineShift(.51f))
+    override val headline3 = base.copy(fontSize = Sizes.headline3, baselineShift = BaselineShift(.51f))
+    override val large = base.copy(fontSize = Sizes.large, baselineShift = BaselineShift(.3f))
+    override val basic = base.copy(fontSize = Sizes.basic, baselineShift = BaselineShift(.3f))
+    override val small = base.copy(fontSize = Sizes.small, baselineShift = BaselineShift(.3f))
 }
 
 private object EmphasisTextStylesApp : EmphasisTextStyles {
@@ -100,12 +101,12 @@ private object EmphasisTextStylesApp : EmphasisTextStyles {
         fontStyle = FontStyle.Normal,
     )
 
-    override val headline1 = base.copy(fontSize = Sizes.headline1)
-    override val headline2 = base.copy(fontSize = Sizes.headline2)
-    override val headline3 = base.copy(fontSize = Sizes.headline3)
-    override val large = base.copy(fontSize = Sizes.large)
-    override val basic = base.copy(fontSize = Sizes.basic)
-    override val small = base.copy(fontSize = Sizes.small)
+    override val headline1 = base.copy(fontSize = Sizes.headline1, baselineShift = BaselineShift(.32f))
+    override val headline2 = base.copy(fontSize = Sizes.headline2, baselineShift = BaselineShift(.51f))
+    override val headline3 = base.copy(fontSize = Sizes.headline3, baselineShift = BaselineShift(.51f))
+    override val large = base.copy(fontSize = Sizes.large, baselineShift = BaselineShift(.3f))
+    override val basic = base.copy(fontSize = Sizes.basic, baselineShift = BaselineShift(.3f))
+    override val small = base.copy(fontSize = Sizes.small, baselineShift = BaselineShift(.3f))
 }
 
 private object SatsHeadlineNormalTextStylesApp : SatsHeadlineNormalTextStyles {
@@ -115,7 +116,7 @@ private object SatsHeadlineNormalTextStylesApp : SatsHeadlineNormalTextStyles {
         fontStyle = FontStyle.Italic,
     )
 
-    override val headline1 = base.copy(fontSize = Sizes.headline1)
+    override val headline1 = base.copy(fontSize = Sizes.headline1, baselineShift = BaselineShift(.1f))
     override val headline2 = base.copy(fontSize = Sizes.headline2)
     override val headline3 = base.copy(fontSize = Sizes.headline3)
     override val large = base.copy(fontSize = Sizes.large)
@@ -130,7 +131,7 @@ private object SatsHeadlineEmphasisTextStylesApp : SatsHeadlineEmphasisTextStyle
         fontStyle = FontStyle.Italic,
     )
 
-    override val headline1 = base.copy(fontSize = Sizes.headline1)
+    override val headline1 = base.copy(fontSize = Sizes.headline1, baselineShift = BaselineShift(.1f))
     override val headline2 = base.copy(fontSize = Sizes.headline2)
     override val headline3 = base.copy(fontSize = Sizes.headline3)
     override val large = base.copy(fontSize = Sizes.large)


### PR DESCRIPTION
- Make title bold
- Add some spacing between title and message
- Move snackbar dismiss action to top right corner
- Always put leading icons to the top left
- Make leading icons required
- Span full width for title, message and dismiss action
- Move regular action underneath the message, aligned to the right

What's your opinion on this? It looks a little wonky with the icons in grandma mode (due to their size not changing alongside the font scale), but other than that, I feel like this makes some sense.

## Screenshots

![image](https://github.com/sats-group/sats-dna-android/assets/386122/181e6029-3355-48ec-b0c4-dc534f087e0d)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/964744b5-a1f3-4869-ae15-5075cfc32f88)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/140ea8e2-4f68-4ebd-aacc-6f1fc18f383e)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/a723462a-34df-41e8-801f-2c7da291e7b6)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/e572df45-3e3a-4e81-b849-c29505912248)
