### PR TITLE
NMA-6142: Add new border colors to outlined text fields

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
@@ -268,6 +268,19 @@ private fun GraphicalElements() {
                 contentColor = null,
             )
         }
+        Section("Border", SectionLevel.Level2) {
+            val base = SatsTheme.colors2.graphicalElements.border
+
+            ColorSample(
+                backgroundColor = base.default named "Default",
+                contentColor = null,
+            )
+
+            ColorSample(
+                backgroundColor = base.focused named "Focused",
+                contentColor = null,
+            )
+        }
 
         Section("Skeleton", SectionLevel.Level2) {
             ColorSample(

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
@@ -190,6 +190,7 @@ class SatsColors2(
 
     class GraphicalElements(
         val divider: Divider,
+        val border: Border,
         val skeleton: Color,
         val navBar: NavBar,
         val progressBar: ProgressBar,
@@ -207,6 +208,11 @@ class SatsColors2(
         class Divider(
             val default: Color,
             val alternate: Color,
+        )
+
+        class Border(
+            val default: Color,
+            val focused: Color,
         )
 
         class NavBar(

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
@@ -121,6 +121,10 @@ internal val SatsDarkColors2 = SatsColors2(
             default = SatsColorPrimitives.Black80,
             alternate = SatsColorPrimitives.White40,
         ),
+        border = SatsColors2.GraphicalElements.Border(
+            default = SatsColorPrimitives.Black70,
+            focused = SatsColorPrimitives.White40,
+        ),
         skeleton = SatsColorPrimitives.Black80,
         navBar = SatsColors2.GraphicalElements.NavBar(
             selected = SatsColorPrimitives.White100,

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
@@ -122,6 +122,10 @@ internal val SatsLightColors2 = SatsColors2(
             default = SatsColorPrimitives.SatsLightGrey15,
             alternate = SatsColorPrimitives.BlackO20,
         ),
+        border = SatsColors2.GraphicalElements.Border(
+            default = SatsColorPrimitives.SatsLightGrey15,
+            focused = SatsColorPrimitives.SatsBlue40,
+        ),
         skeleton = SatsColorPrimitives.SatsLightGrey15,
         navBar = SatsColors2.GraphicalElements.NavBar(
             selected = SatsColorPrimitives.SatsBlue,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
@@ -3,17 +3,23 @@ package com.sats.dna.components
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.TextFieldColors
-import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.VisualTransformation
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
+import androidx.compose.material.ContentAlpha as M2ContentAlpha
+import androidx.compose.material.LocalContentAlpha as M2LocalContentAlpha
+import androidx.compose.material.LocalContentColor as M2LocalContentColor
+import androidx.compose.material.MaterialTheme as M2MaterialTheme
+import androidx.compose.material.OutlinedTextField as M2OutlinedTextField
+import androidx.compose.material.TextFieldColors as M2TextFieldColors
+import androidx.compose.material.TextFieldDefaults as M2TextFieldDefaults
 import androidx.compose.material3.OutlinedTextField as M3OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults as M3OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors as M3TextFieldColors
 
 @Composable
@@ -31,9 +37,9 @@ fun SatsOutlinedTextField(
     singleLine: Boolean = false,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
-    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors(),
+    colors: M2TextFieldColors = SatsOutlinedTextFieldDefaults.colors(),
 ) {
-    OutlinedTextField(
+    M2OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         modifier = modifier,
@@ -48,6 +54,57 @@ fun SatsOutlinedTextField(
         minLines = minLines,
         colors = colors,
     )
+}
+
+object SatsOutlinedTextFieldDefaults {
+    @Composable
+    fun colors(
+        textColor: Color = M2LocalContentColor.current.copy(M2LocalContentAlpha.current),
+        disabledTextColor: Color = textColor.copy(M2ContentAlpha.disabled),
+        backgroundColor: Color = Color.Transparent,
+        cursorColor: Color = M2MaterialTheme.colors.primary,
+        errorCursorColor: Color = M2MaterialTheme.colors.error,
+        focusedBorderColor: Color = SatsTheme.colors2.graphicalElements.border.focused,
+        unfocusedBorderColor: Color = SatsTheme.colors2.graphicalElements.border.default,
+        disabledBorderColor: Color = SatsTheme.colors2.graphicalElements.border.default,
+        errorBorderColor: Color = SatsTheme.colors2.graphicalElements.signal.error,
+        leadingIconColor: Color = M2MaterialTheme.colors.onSurface.copy(alpha = M2TextFieldDefaults.IconOpacity),
+        disabledLeadingIconColor: Color = leadingIconColor.copy(alpha = M2ContentAlpha.disabled),
+        errorLeadingIconColor: Color = leadingIconColor,
+        trailingIconColor: Color = M2MaterialTheme.colors.onSurface.copy(alpha = M2TextFieldDefaults.IconOpacity),
+        disabledTrailingIconColor: Color = trailingIconColor.copy(alpha = M2ContentAlpha.disabled),
+        errorTrailingIconColor: Color = M2MaterialTheme.colors.error,
+        focusedLabelColor: Color = M2MaterialTheme.colors.primary.copy(alpha = M2ContentAlpha.high),
+        unfocusedLabelColor: Color = M2MaterialTheme.colors.onSurface.copy(M2ContentAlpha.medium),
+        disabledLabelColor: Color = unfocusedLabelColor.copy(M2ContentAlpha.disabled),
+        errorLabelColor: Color = M2MaterialTheme.colors.error,
+        placeholderColor: Color = M2MaterialTheme.colors.onSurface.copy(M2ContentAlpha.medium),
+        disabledPlaceholderColor: Color = placeholderColor.copy(M2ContentAlpha.disabled),
+    ): M2TextFieldColors {
+        return M2TextFieldDefaults.outlinedTextFieldColors(
+            textColor = textColor,
+            disabledTextColor = disabledTextColor,
+            backgroundColor = backgroundColor,
+            cursorColor = cursorColor,
+            errorCursorColor = errorCursorColor,
+            focusedBorderColor = focusedBorderColor,
+            unfocusedBorderColor = unfocusedBorderColor,
+            disabledBorderColor = disabledBorderColor,
+            errorBorderColor = errorBorderColor,
+            leadingIconColor = leadingIconColor,
+            disabledLeadingIconColor = disabledLeadingIconColor,
+            errorLeadingIconColor = errorLeadingIconColor,
+            trailingIconColor = trailingIconColor,
+            disabledTrailingIconColor = disabledTrailingIconColor,
+            errorTrailingIconColor = errorTrailingIconColor,
+            focusedLabelColor = focusedLabelColor,
+            unfocusedLabelColor = unfocusedLabelColor,
+            disabledLabelColor = disabledLabelColor,
+            errorLabelColor = errorLabelColor,
+            placeholderColor = placeholderColor,
+            disabledPlaceholderColor = disabledPlaceholderColor,
+        )
+    }
 }
 
 @Composable
@@ -66,7 +123,7 @@ fun M3SatsOutlinedTextField(
     singleLine: Boolean = false,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
-    colors: M3TextFieldColors = OutlinedTextFieldDefaults.colors(),
+    colors: M3TextFieldColors = M3SatsOutlinedTextFieldDefaults.colors(),
 ) {
     M3OutlinedTextField(
         value = value,
@@ -84,6 +141,101 @@ fun M3SatsOutlinedTextField(
         minLines = minLines,
         colors = colors,
     )
+}
+
+object M3SatsOutlinedTextFieldDefaults {
+    @Composable
+    fun colors(
+        focusedTextColor: Color = Color.Unspecified,
+        unfocusedTextColor: Color = Color.Unspecified,
+        disabledTextColor: Color = Color.Unspecified,
+        errorTextColor: Color = Color.Unspecified,
+        focusedContainerColor: Color = Color.Unspecified,
+        unfocusedContainerColor: Color = Color.Unspecified,
+        disabledContainerColor: Color = Color.Unspecified,
+        errorContainerColor: Color = Color.Unspecified,
+        cursorColor: Color = Color.Unspecified,
+        errorCursorColor: Color = Color.Unspecified,
+        selectionColors: TextSelectionColors? = null,
+        focusedBorderColor: Color = SatsTheme.colors2.graphicalElements.border.focused,
+        unfocusedBorderColor: Color = SatsTheme.colors2.graphicalElements.border.default,
+        disabledBorderColor: Color = SatsTheme.colors2.graphicalElements.border.default,
+        errorBorderColor: Color = SatsTheme.colors2.graphicalElements.signal.error,
+        focusedLeadingIconColor: Color = Color.Unspecified,
+        unfocusedLeadingIconColor: Color = Color.Unspecified,
+        disabledLeadingIconColor: Color = Color.Unspecified,
+        errorLeadingIconColor: Color = Color.Unspecified,
+        focusedTrailingIconColor: Color = Color.Unspecified,
+        unfocusedTrailingIconColor: Color = Color.Unspecified,
+        disabledTrailingIconColor: Color = Color.Unspecified,
+        errorTrailingIconColor: Color = Color.Unspecified,
+        focusedLabelColor: Color = Color.Unspecified,
+        unfocusedLabelColor: Color = Color.Unspecified,
+        disabledLabelColor: Color = Color.Unspecified,
+        errorLabelColor: Color = Color.Unspecified,
+        focusedPlaceholderColor: Color = Color.Unspecified,
+        unfocusedPlaceholderColor: Color = Color.Unspecified,
+        disabledPlaceholderColor: Color = Color.Unspecified,
+        errorPlaceholderColor: Color = Color.Unspecified,
+        focusedSupportingTextColor: Color = Color.Unspecified,
+        unfocusedSupportingTextColor: Color = Color.Unspecified,
+        disabledSupportingTextColor: Color = Color.Unspecified,
+        errorSupportingTextColor: Color = Color.Unspecified,
+        focusedPrefixColor: Color = Color.Unspecified,
+        unfocusedPrefixColor: Color = Color.Unspecified,
+        disabledPrefixColor: Color = Color.Unspecified,
+        errorPrefixColor: Color = Color.Unspecified,
+        focusedSuffixColor: Color = Color.Unspecified,
+        unfocusedSuffixColor: Color = Color.Unspecified,
+        disabledSuffixColor: Color = Color.Unspecified,
+        errorSuffixColor: Color = Color.Unspecified,
+    ): M3TextFieldColors {
+        return M3OutlinedTextFieldDefaults.colors(
+            focusedTextColor = focusedTextColor,
+            unfocusedTextColor = unfocusedTextColor,
+            disabledTextColor = disabledTextColor,
+            errorTextColor = errorTextColor,
+            focusedContainerColor = focusedContainerColor,
+            unfocusedContainerColor = unfocusedContainerColor,
+            disabledContainerColor = disabledContainerColor,
+            errorContainerColor = errorContainerColor,
+            cursorColor = cursorColor,
+            errorCursorColor = errorCursorColor,
+            selectionColors = selectionColors,
+            focusedBorderColor = focusedBorderColor,
+            unfocusedBorderColor = unfocusedBorderColor,
+            disabledBorderColor = disabledBorderColor,
+            errorBorderColor = errorBorderColor,
+            focusedLeadingIconColor = focusedLeadingIconColor,
+            unfocusedLeadingIconColor = unfocusedLeadingIconColor,
+            disabledLeadingIconColor = disabledLeadingIconColor,
+            errorLeadingIconColor = errorLeadingIconColor,
+            focusedTrailingIconColor = focusedTrailingIconColor,
+            unfocusedTrailingIconColor = unfocusedTrailingIconColor,
+            disabledTrailingIconColor = disabledTrailingIconColor,
+            errorTrailingIconColor = errorTrailingIconColor,
+            focusedLabelColor = focusedLabelColor,
+            unfocusedLabelColor = unfocusedLabelColor,
+            disabledLabelColor = disabledLabelColor,
+            errorLabelColor = errorLabelColor,
+            focusedPlaceholderColor = focusedPlaceholderColor,
+            unfocusedPlaceholderColor = unfocusedPlaceholderColor,
+            disabledPlaceholderColor = disabledPlaceholderColor,
+            errorPlaceholderColor = errorPlaceholderColor,
+            focusedSupportingTextColor = focusedSupportingTextColor,
+            unfocusedSupportingTextColor = unfocusedSupportingTextColor,
+            disabledSupportingTextColor = disabledSupportingTextColor,
+            errorSupportingTextColor = errorSupportingTextColor,
+            focusedPrefixColor = focusedPrefixColor,
+            unfocusedPrefixColor = unfocusedPrefixColor,
+            disabledPrefixColor = disabledPrefixColor,
+            errorPrefixColor = errorPrefixColor,
+            focusedSuffixColor = focusedSuffixColor,
+            unfocusedSuffixColor = unfocusedSuffixColor,
+            disabledSuffixColor = disabledSuffixColor,
+            errorSuffixColor = errorSuffixColor,
+        )
+    }
 }
 
 @LightDarkPreview


### PR DESCRIPTION
| Before |   After  |
|-|-|
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/3df53c2f-da9c-4d76-972b-66f2ebe2049f) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/25fc9ebe-4b51-4b95-8a96-f442fbe873ed) |
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/a6ab9c80-e184-40eb-84ed-c0e9be008b17) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/7a5a92ad-6856-458f-ad3c-f71433ee3feb) |