### PR TITLE
NMA-6184: Add workout foreground colors and SatsWorkoutTag

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
@@ -587,28 +587,28 @@ private fun GraphicalElements() {
             val base = SatsTheme.colors2.graphicalElements.workouts
 
             ColorSample(
-                backgroundColor = base.pt named "PT",
-                contentColor = null,
+                backgroundColor = base.pt.bg named "PT",
+                contentColor = base.pt.fg named "PT",
             )
 
             ColorSample(
-                backgroundColor = base.gx named "GX",
-                contentColor = null,
+                backgroundColor = base.gx.bg named "GX",
+                contentColor = base.gx.fg named "GX",
             )
 
             ColorSample(
-                backgroundColor = base.treatments named "Treatments",
-                contentColor = null,
+                backgroundColor = base.treatments.bg named "Treatments",
+                contentColor = base.treatments.fg named "Treatments",
             )
 
             ColorSample(
-                backgroundColor = base.gymfloor named "Gymfloor",
-                contentColor = null,
+                backgroundColor = base.gymfloor.bg named "Gymfloor",
+                contentColor = base.gymfloor.fg named "Gymfloor",
             )
 
             ColorSample(
-                backgroundColor = base.ownTrainingOther named "Own Training/Other",
-                contentColor = null,
+                backgroundColor = base.ownTrainingOther.bg named "Own Training/Other",
+                contentColor = base.ownTrainingOther.fg named "Own Training/Other",
             )
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,6 +16,8 @@ import com.sats.dna.components.SatsRewardsTag
 import com.sats.dna.components.SatsTag
 import com.sats.dna.components.SatsTagColor
 import com.sats.dna.components.SatsTagPlaceholder
+import com.sats.dna.components.SatsWorkoutTag
+import com.sats.dna.components.SatsWorkoutTagColor
 import com.sats.dna.theme.SatsTheme
 import com.sats.dna.tooling.LightDarkPreview
 
@@ -29,6 +33,7 @@ private fun TagsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
         Column(
             Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(innerPadding)
                 .padding(vertical = SatsTheme.spacing.m),
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxl),
@@ -43,6 +48,12 @@ private fun TagsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
             Section("Rewards Tags") {
                 SatsRewardsLevel.entries.forEach { level ->
                     SatsRewardsTag(level)
+                }
+            }
+
+            Section("Workout Tags") {
+                SatsWorkoutTagColor.entries.forEach { color ->
+                    SatsWorkoutTag("$color", color = color)
                 }
             }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
@@ -436,12 +436,37 @@ class SatsColors2(
         }
 
         class Workouts(
-            val pt: Color,
-            val gx: Color,
-            val treatments: Color,
-            val gymfloor: Color,
-            val ownTrainingOther: Color,
-        )
+            val pt: Pt,
+            val gx: Gx,
+            val treatments: Treatments,
+            val gymfloor: Gymfloor,
+            val ownTrainingOther: OwnTrainingOther,
+        ) {
+            class Pt(
+                val bg: Color,
+                val fg: Color,
+            )
+
+            class Gx(
+                val bg: Color,
+                val fg: Color,
+            )
+
+            class Treatments(
+                val bg: Color,
+                val fg: Color,
+            )
+
+            class Gymfloor(
+                val bg: Color,
+                val fg: Color,
+            )
+
+            class OwnTrainingOther(
+                val bg: Color,
+                val fg: Color,
+            )
+        }
     }
 
     class Backgrounds(

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
@@ -278,11 +278,26 @@ internal val SatsDarkColors2 = SatsColors2(
             ),
         ),
         workouts = SatsColors2.GraphicalElements.Workouts(
-            pt = SatsColorPrimitives.UranianBlue70,
-            gx = SatsColorPrimitives.SalmonPink70,
-            treatments = SatsColorPrimitives.CaribbeanCurrent70,
-            gymfloor = SatsColorPrimitives.Tangerine70,
-            ownTrainingOther = SatsColorPrimitives.Celadon70,
+            pt = SatsColors2.GraphicalElements.Workouts.Pt(
+                fg = SatsColorPrimitives.BrightBlue160,
+                bg = SatsColorPrimitives.UranianBlue70,
+            ),
+            gx = SatsColors2.GraphicalElements.Workouts.Gx(
+                fg = SatsColorPrimitives.ChiliRed170,
+                bg = SatsColorPrimitives.SalmonPink70,
+            ),
+            treatments = SatsColors2.GraphicalElements.Workouts.Treatments(
+                fg = SatsColorPrimitives.SpringGreen10,
+                bg = SatsColorPrimitives.CaribbeanCurrent70,
+            ),
+            gymfloor = SatsColors2.GraphicalElements.Workouts.Gymfloor(
+                fg = SatsColorPrimitives.Gold170,
+                bg = SatsColorPrimitives.Tangerine70,
+            ),
+            ownTrainingOther = SatsColors2.GraphicalElements.Workouts.OwnTrainingOther(
+                fg = SatsColorPrimitives.SpringGreen170,
+                bg = SatsColorPrimitives.Celadon70,
+            ),
         ),
     ),
     backgrounds = SatsColors2.Backgrounds(

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
@@ -279,11 +279,26 @@ internal val SatsLightColors2 = SatsColors2(
             ),
         ),
         workouts = SatsColors2.GraphicalElements.Workouts(
-            pt = SatsColorPrimitives.UranianBlue100,
-            gx = SatsColorPrimitives.SalmonPink100,
-            treatments = SatsColorPrimitives.CaribbeanCurrent100,
-            gymfloor = SatsColorPrimitives.Tangerine100,
-            ownTrainingOther = SatsColorPrimitives.Celadon100,
+            pt = SatsColors2.GraphicalElements.Workouts.Pt(
+                fg = SatsColorPrimitives.BrightBlue160,
+                bg = SatsColorPrimitives.UranianBlue100,
+            ),
+            gx = SatsColors2.GraphicalElements.Workouts.Gx(
+                fg = SatsColorPrimitives.ChiliRed170,
+                bg = SatsColorPrimitives.SalmonPink100,
+            ),
+            treatments = SatsColors2.GraphicalElements.Workouts.Treatments(
+                fg = SatsColorPrimitives.SpringGreen10,
+                bg = SatsColorPrimitives.CaribbeanCurrent100,
+            ),
+            gymfloor = SatsColors2.GraphicalElements.Workouts.Gymfloor(
+                fg = SatsColorPrimitives.Gold170,
+                bg = SatsColorPrimitives.Tangerine100,
+            ),
+            ownTrainingOther = SatsColors2.GraphicalElements.Workouts.OwnTrainingOther(
+                fg = SatsColorPrimitives.SpringGreen170,
+                bg = SatsColorPrimitives.Celadon100,
+            ),
         ),
     ),
     backgrounds = SatsColors2.Backgrounds(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
@@ -70,6 +70,37 @@ enum class SatsRewardsLevel {
 }
 
 @Composable
+fun SatsWorkoutTag(
+    text: String,
+    color: SatsWorkoutTagColor,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor = when (color) {
+        SatsWorkoutTagColor.Pt -> SatsTheme.colors2.graphicalElements.workouts.pt.bg
+        SatsWorkoutTagColor.Gx -> SatsTheme.colors2.graphicalElements.workouts.gx.bg
+        SatsWorkoutTagColor.Treatment -> SatsTheme.colors2.graphicalElements.workouts.treatments.bg
+        SatsWorkoutTagColor.Gymfloor -> SatsTheme.colors2.graphicalElements.workouts.gymfloor.bg
+        SatsWorkoutTagColor.OwnTrainingOther ->
+            SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther.bg
+    }
+
+    val contentColor = when (color) {
+        SatsWorkoutTagColor.Pt -> SatsTheme.colors2.graphicalElements.workouts.pt.fg
+        SatsWorkoutTagColor.Gx -> SatsTheme.colors2.graphicalElements.workouts.gx.fg
+        SatsWorkoutTagColor.Treatment -> SatsTheme.colors2.graphicalElements.workouts.treatments.fg
+        SatsWorkoutTagColor.Gymfloor -> SatsTheme.colors2.graphicalElements.workouts.gymfloor.fg
+        SatsWorkoutTagColor.OwnTrainingOther ->
+            SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther.fg
+    }
+
+    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+}
+
+enum class SatsWorkoutTagColor {
+    Pt, Gx, Treatment, Gymfloor, OwnTrainingOther,
+}
+
+@Composable
 fun SatsTagPlaceholder(
     text: String,
     modifier: Modifier = Modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/icons/WorkoutTypeIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/icons/WorkoutTypeIcon.kt
@@ -29,12 +29,18 @@ fun WorkoutTypeIcon(type: WorkoutType, contentDescription: String?, modifier: Mo
     }
 
     val color = when (type) {
-        WorkoutType.GroupExercise -> SatsTheme.colors2.graphicalElements.workouts.gx
-        WorkoutType.GymTraining -> SatsTheme.colors2.graphicalElements.workouts.gymfloor
-        WorkoutType.OnlineTraining -> SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther
-        WorkoutType.OwnTraining -> SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther
-        WorkoutType.PtAppointment -> SatsTheme.colors2.graphicalElements.workouts.pt
-        WorkoutType.Unknown -> SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther
+        WorkoutType.GroupExercise ->
+            SatsTheme.colors2.graphicalElements.workouts.gx.bg
+        WorkoutType.GymTraining ->
+            SatsTheme.colors2.graphicalElements.workouts.gymfloor.bg
+        WorkoutType.OnlineTraining ->
+            SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther.bg
+        WorkoutType.OwnTraining ->
+            SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther.bg
+        WorkoutType.PtAppointment ->
+            SatsTheme.colors2.graphicalElements.workouts.pt.bg
+        WorkoutType.Unknown ->
+            SatsTheme.colors2.graphicalElements.workouts.ownTrainingOther.bg
     }
 
     Icon(icon, contentDescription, modifier, color)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
@@ -21,11 +21,11 @@ internal fun WorkoutTypeColorIndicator(
     modifier: Modifier = Modifier,
 ) {
     val color = when (workoutType) {
-        WorkoutType.Pt -> SatsTheme.colors2.graphicalElements.workouts.pt
-        WorkoutType.Gx -> SatsTheme.colors2.graphicalElements.workouts.gx
-        WorkoutType.Treatment -> SatsTheme.colors2.graphicalElements.workouts.treatments
-        WorkoutType.Gymfloor -> SatsTheme.colors2.graphicalElements.workouts.gymfloor
-        WorkoutType.OwnTraining -> SatsTheme.colors2.graphicalElements.workouts.pt
+        WorkoutType.Pt -> SatsTheme.colors2.graphicalElements.workouts.pt.bg
+        WorkoutType.Gx -> SatsTheme.colors2.graphicalElements.workouts.gx.bg
+        WorkoutType.Treatment -> SatsTheme.colors2.graphicalElements.workouts.treatments.bg
+        WorkoutType.Gymfloor -> SatsTheme.colors2.graphicalElements.workouts.gymfloor.bg
+        WorkoutType.OwnTraining -> SatsTheme.colors2.graphicalElements.workouts.pt.bg
     }
 
     Box(


### PR DESCRIPTION
# Summary

Added workout foreground colors and SatsWorkoutTag

JIRA: https://hfnswedenab.atlassian.net/browse/NMA-6184

Figma colors: https://www.figma.com/file/WzKCwRY09zn4rzRVfY0YvdRt/sats-ds-styles?type=design&node-id=9910-26384&mode=design&t=GTuTdDGwsAu9yFeY-4

Figma workout tag: https://www.figma.com/file/Nu1V7557V7KovgpZCNDObQ/%F0%9F%93%B1-sats-app-components-new?type=design&node-id=3744-12&mode=design&t=XOGfADUpeTHR02hK-4

# Screenshots

<img src=https://github.com/sats-group/sats-dna-android/assets/91871637/80885d37-571a-4f1f-a63c-adf44c479f5a width=40%>

<img src=https://github.com/sats-group/sats-dna-android/assets/91871637/94b5d033-4b22-4210-bfb7-0cee5da17d21 width=40%>