### PR TITLE
NMA-6189: Add new On Surface Featured color

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
@@ -752,6 +752,11 @@ private fun Surfaces() {
         )
 
         ColorSample(
+            backgroundColor = base.primary.bg.default named "Primary Default",
+            contentColor = base.primary.fg.featured named "Featured",
+        )
+
+        ColorSample(
             backgroundColor = base.primary.bg.hover named "Primary Hover",
             contentColor = base.primary.fg.default named "Primary Default",
         )
@@ -812,6 +817,11 @@ private fun Surfaces() {
         )
 
         ColorSample(
+            backgroundColor = base.secondary.bg.default named "Secondary Default",
+            contentColor = base.secondary.fg.featured named "Featured",
+        )
+
+        ColorSample(
             backgroundColor = base.secondary.bg.hover named "Secondary Hover",
             contentColor = base.secondary.fg.default named "Secondary Default",
         )
@@ -838,7 +848,7 @@ private fun Surfaces() {
 
         ColorSample(
             backgroundColor = base.fixed.bg.default named "Fixed Default",
-            contentColor = base.fixed.fg.disabled named "Fixed Disabled",
+            contentColor = base.fixed.fg.featured named "Fixed Featured",
         )
 
         ColorSample(

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
@@ -551,6 +551,7 @@ class SatsColors2(
                 val waitlist: Color,
                 val neutral: Color,
                 val information: Color,
+                val featured: Color,
             )
         }
 
@@ -574,6 +575,7 @@ class SatsColors2(
                 val waitlist: Color,
                 val neutral: Color,
                 val information: Color,
+                val featured: Color,
             )
         }
 
@@ -591,6 +593,7 @@ class SatsColors2(
                 val default: Color,
                 val alternate: Color,
                 val disabled: Color,
+                val featured: Color,
             )
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
@@ -355,6 +355,7 @@ internal val SatsDarkColors2 = SatsColors2(
                 waitlist = SatsColorPrimitives.EgyptianPurple60,
                 neutral = SatsColorPrimitives.Black40,
                 information = SatsColorPrimitives.BrightBlue60,
+                featured = SatsColorPrimitives.SatsCoral90,
             ),
         ),
         secondary = SatsColors2.Surfaces.Secondary(
@@ -373,6 +374,7 @@ internal val SatsDarkColors2 = SatsColors2(
                 waitlist = SatsColorPrimitives.EgyptianPurple60,
                 neutral = SatsColorPrimitives.Black40,
                 information = SatsColorPrimitives.BrightBlue60,
+                featured = SatsColorPrimitives.SatsCoral90,
             ),
         ),
         fixed = SatsColors2.Surfaces.Fixed(
@@ -385,6 +387,7 @@ internal val SatsDarkColors2 = SatsColors2(
                 default = SatsColorPrimitives.White100,
                 alternate = SatsColorPrimitives.White85,
                 disabled = SatsColorPrimitives.White65,
+                featured = SatsColorPrimitives.SatsCoral90,
             ),
         ),
     ),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
@@ -356,6 +356,7 @@ internal val SatsLightColors2 = SatsColors2(
                 waitlist = SatsColorPrimitives.EgyptianPurple100,
                 neutral = SatsColorPrimitives.Black60,
                 information = SatsColorPrimitives.BrightBlue160,
+                featured = SatsColorPrimitives.SatsCoral120,
             ),
         ),
         secondary = SatsColors2.Surfaces.Secondary(
@@ -374,6 +375,7 @@ internal val SatsLightColors2 = SatsColors2(
                 waitlist = SatsColorPrimitives.EgyptianPurple100,
                 neutral = SatsColorPrimitives.Black60,
                 information = SatsColorPrimitives.BrightBlue160,
+                featured = SatsColorPrimitives.SatsCoral120,
             ),
         ),
         fixed = SatsColors2.Surfaces.Fixed(
@@ -386,6 +388,7 @@ internal val SatsLightColors2 = SatsColors2(
                 default = SatsColorPrimitives.White100,
                 alternate = SatsColorPrimitives.White85,
                 disabled = SatsColorPrimitives.White65,
+                featured = SatsColorPrimitives.SatsCoral120,
             ),
         ),
     ),


### PR DESCRIPTION
## On Surface Primary

![image](https://github.com/sats-group/sats-dna-android/assets/386122/b0529633-a419-4e24-bb6d-db0c1d094fa9)
![image](https://github.com/sats-group/sats-dna-android/assets/386122/b7938eb4-f610-4105-9e9a-19a094b40f96)

## On Surface Primary

![image](https://github.com/sats-group/sats-dna-android/assets/386122/b054cc0f-e3aa-4e07-9baf-3597ea502b08)
![image](https://github.com/sats-group/sats-dna-android/assets/386122/8202a906-1bf6-4db9-9eb2-ffd240b4b7d9)

## On Surface Fixed

![image](https://github.com/sats-group/sats-dna-android/assets/386122/1f16ac87-8c2c-4d7b-839a-875a04227a5d)
![image](https://github.com/sats-group/sats-dna-android/assets/386122/9ee9f1c8-dd53-44c7-a257-d786af0d8074)
