### PR TITLE
NMA-6247: Increase icon size for empty state component

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
@@ -69,7 +69,7 @@ fun SatsEmptyState(
         verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        MaterialIcon(icon, contentDescription = null, Modifier.size(18.dp))
+        MaterialIcon(icon, contentDescription = null, Modifier.size(36.dp))
 
         Column(
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),


### PR DESCRIPTION
| Before |   After  |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/fe697a17-a7c7-4ae5-a15a-c2ed60457a31)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/37583141-16f6-40de-99ce-c4453b7bce65)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/d168d6e1-7460-423f-9c52-d5dfa9d9cf59)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/d42a80f4-e8f3-41d2-a12e-e2af7aa8ce66)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/91037b95-c1c5-4473-8181-96559e8c8575)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/63faa569-4420-4c60-9c78-975985f62bde)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/e24e325a-3a74-4d48-9f2b-86161a7acdf6)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/558afe6b-677c-4127-9d88-13a6bda4eaac)|
