### PR TITLE
NMA-6252: Deprecate own multi-preview annotations

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BannerSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BannerSampleScreen.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsBanner
 import com.sats.dna.components.SatsBannerAction
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object BannerSampleScreen : SampleScreen(
     name = "Banner",
@@ -44,7 +44,7 @@ private fun BannerScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) 
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BannerScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BottomNavigationSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BottomNavigationSampleScreen.kt
@@ -6,11 +6,11 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.navigation.SatsBottomNavigation
 import com.sats.dna.components.navigation.SatsBottomNavigationItem
 import com.sats.dna.components.navigation.rememberSatsBottomNavigationState
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object BottomNavigationSampleScreen : SampleScreen(
     name = "Bottom Navigation",
@@ -71,7 +71,7 @@ private fun rememberSampleBottomNavigationState() = rememberSatsBottomNavigation
     ),
 )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BrandLogoSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/BrandLogoSampleScreen.kt
@@ -7,11 +7,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.Brand
 import com.sats.dna.components.BrandLogo
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object BrandLogoSampleScreen : SampleScreen(
     name = "Brand Logo",
@@ -57,7 +57,7 @@ private fun BrandLogoScreen(navigateUp: () -> Unit, modifier: Modifier = Modifie
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BrandLogoScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsFilterChip
 import com.sats.dna.components.SatsSurface
@@ -29,7 +30,6 @@ import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.components.button.SatsIconButton
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ButtonsSampleScreen : SampleScreen(
     name = "Buttons",
@@ -205,7 +205,7 @@ private fun ControlPanel(state: ControlPanelState) {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CampaignModuleSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CampaignModuleSampleScreen.kt
@@ -8,9 +8,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsCampaignModule
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object CampaignModuleSampleScreen : SampleScreen(
     name = "Campaign Module",
@@ -55,7 +55,7 @@ private fun CampaignModulesScreen(navigateUp: () -> Unit, modifier: Modifier = M
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun CampaignModulesScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CardSampleScreen.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object CardSampleScreen : SampleScreen(
     name = "Card",
@@ -65,7 +65,7 @@ private fun SatsCardScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeBadgeSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeBadgeSampleScreen.kt
@@ -13,10 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsChallengeBadge
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ChallengeBadgeSampleScreen : SampleScreen(
     name = "Challenge Badges",
@@ -67,7 +67,7 @@ private fun BadgeSample(imageUrl: String?, progress: Float? = null, label: Strin
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ChallengeBadgeScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CheckboxSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CheckboxSampleScreen.kt
@@ -15,12 +15,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsCheckbox
 import com.sats.dna.components.SatsCheckboxColors
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.SatsTriStateCheckbox
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object CheckboxSampleScreen : SampleScreen(
     name = "Checkbox",
@@ -115,7 +115,7 @@ private fun ToggleableState.next() = when (this) {
     ToggleableState.On -> ToggleableState.Off
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun CheckboxScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChipsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChipsSampleScreen.kt
@@ -15,13 +15,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsFilterChip
 import com.sats.dna.components.SatsInputChip
 import com.sats.dna.components.SatsInputChipClearAction
 import com.sats.dna.components.chip.SatsChip
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ChipsSampleScreen : SampleScreen(
     name = "Chips",
@@ -99,7 +99,7 @@ private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) 
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CircularProgressIndicatorSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CircularProgressIndicatorSampleScreen.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsCircularProgressIndicator
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object CircularProgressIndicatorSampleScreen : SampleScreen(
     name = "Circular Progress Indicator",
@@ -46,7 +46,7 @@ private fun CircularProgressIndicatorScreen(navigateUp: () -> Unit, modifier: Mo
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object Colors2SampleScreen : SampleScreen(
     name = "Colors2",
@@ -1016,7 +1016,7 @@ class NamedColor(val name: String, val color: Color) {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ColorSamplePreview() {
     SatsTheme {
@@ -1032,7 +1032,7 @@ private fun ColorSamplePreview() {
 
 private infix fun Color.named(name: String) = NamedColor(name, this)
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Colors2ScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ColorsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ColorsSampleScreen.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.colors.SatsColors
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ColorsSampleScreen : SampleScreen(
     name = "Colors",
@@ -240,7 +240,7 @@ private fun SatsColors.toListItems(): List<ListItem> {
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ColorsScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CompletedWorkoutListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CompletedWorkoutListItemSampleScreen.kt
@@ -10,13 +10,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.CompletedWorkoutListItem
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.icons.WorkoutType
 import com.sats.dna.components.icons.WorkoutTypeIcon
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object CompletedWorkoutListItemSampleScreen : SampleScreen(
     name = "Completed Workout List Item",
@@ -57,7 +57,7 @@ private fun CompletedWorkoutListItemScreen(navigateUp: () -> Unit, modifier: Mod
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/DividersSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/DividersSampleScreen.kt
@@ -12,12 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.SatsVerticalDivider
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object DividersSampleScreen : SampleScreen(
     name = "Dividers",
@@ -74,7 +74,7 @@ private fun Section(label: String, modifier: Modifier = Modifier, content: @Comp
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DividersScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/EmptyStateSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/EmptyStateSampleScreen.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsEmptyStateAction
 import com.sats.dna.components.SatsEmptyStateCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object EmptyStateSampleScreen : SampleScreen(
     name = "Empty State",
@@ -68,7 +68,7 @@ private fun EmptyStateScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EmptyStateScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FriendsBookingStatusSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FriendsBookingStatusSampleScreen.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.sessiondetails.FriendsBookingState
 import com.sats.dna.components.sessiondetails.FriendsBookingStatus
 import com.sats.dna.components.sessiondetails.FriendsBookingStatusListItem
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object FriendsBookingStatusSampleScreen : SampleScreen(
     name = "Friends Booking Status List Item",
@@ -85,7 +85,7 @@ private val friendsBookingStates = listOf(
     ),
 )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
@@ -8,12 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.AdvancedTrailingContent
 import com.sats.dna.components.SatsGeneralListItem
 import com.sats.dna.components.SatsGeneralListItemDefaults
 import com.sats.dna.components.SimpleTrailingContent
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object GeneralListItemSampleScreen : SampleScreen(
     name = "General List Item",
@@ -81,7 +81,7 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/IconsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/IconsSampleScreen.kt
@@ -17,11 +17,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.chip.SatsChip
 import com.sats.dna.icons.SatsIcons
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object IconsSampleScreen : SampleScreen(
     name = "Icons",
@@ -159,7 +159,7 @@ private val SatsIcons.allIcons: List<NamedIcon>
         NamedIcon("workoutPt", workoutPt),
     )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/JoinYourFriendsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/JoinYourFriendsSampleScreen.kt
@@ -3,12 +3,12 @@ package com.sats.dna.sample.screens
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.JoinYourFriendsCard
 import com.sats.dna.components.Pill
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.sample.internal.SampleProfilePicture
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object JoinYourFriendsSampleScreen : SampleScreen(
     name = "Join Your Friends",
@@ -32,7 +32,7 @@ private fun JoinYourFriendsSampleScreen(navigateUp: () -> Unit, modifier: Modifi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun JoinYourFriendsSampleScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/PlaceholdersSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/PlaceholdersSampleScreen.kt
@@ -11,12 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.PlaceholderParagraph
 import com.sats.dna.components.PlaceholderText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object PlaceholdersSampleScreen : SampleScreen(
     name = "Placeholders",
@@ -57,7 +57,7 @@ private fun PlaceholderScreen(navigateUp: () -> Unit, modifier: Modifier = Modif
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProgressBarsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProgressBarsSampleScreen.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.progressbar.LinearProgressBar
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ProgressBarsSampleScreen : SampleScreen(
     name = "Progress Bars",
@@ -36,7 +36,7 @@ private fun ProgressBarsScreen(navigateUp: () -> Unit, modifier: Modifier = Modi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProteinBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProteinBarSampleScreen.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.proteinbar.SatsProteinBar
 import com.sats.dna.components.proteinbar.SatsProteinBarAction
 import com.sats.dna.components.proteinbar.SatsProteinBarDefaults
 import com.sats.dna.components.proteinbar.SatsProteinBarTheme
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ProteinBarSampleScreen : SampleScreen(
     name = "Protein Bar",
@@ -94,7 +94,7 @@ private fun ProteinBarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ProteinBarScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/RadioButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/RadioButtonsSampleScreen.kt
@@ -10,9 +10,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsRadioButton
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object RadioButtonsSampleScreen : SampleScreen(
     name = "Radio Buttons",
@@ -51,7 +51,7 @@ private fun LabeledRadioButton(label: String, enabled: Boolean, selected: Boolea
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScaleBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScaleBarSampleScreen.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsScaleBar
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ScaleBarSampleScreen : SampleScreen(
     name = "Scale Bar",
@@ -40,7 +40,7 @@ private fun ScaleBarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ScaleBarScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScheduleSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScheduleSampleScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.upcomingworkouts.Schedule
 import com.sats.dna.components.upcomingworkouts.SchedulePlaceholder
@@ -12,7 +13,6 @@ import com.sats.dna.components.upcomingworkouts.UpcomingWorkout
 import com.sats.dna.components.upcomingworkouts.WaitingListStatus
 import com.sats.dna.components.upcomingworkouts.WorkoutType
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object ScheduleSampleScreen : SampleScreen(
     name = "Schedule",
@@ -77,7 +77,7 @@ private fun ScheduleScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SearchBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SearchBarSampleScreen.kt
@@ -13,10 +13,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSearchBar
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object SearchBarSampleScreen : SampleScreen(
     name = "Search Bar",
@@ -64,7 +64,7 @@ private fun SearchBarSampleScreen(navigateUp: () -> Unit, modifier: Modifier = M
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SearchBarSampleScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SessionDetailsInfoLabelSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SessionDetailsInfoLabelSampleScreen.kt
@@ -7,12 +7,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.sessiondetails.SessionDetailsInfoLabel
 import com.sats.dna.components.sessiondetails.SessionDetailsInfoSection
 import com.sats.dna.components.sessiondetails.SessionDetailsInfoSectionPlaceholder
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object SessionDetailsInfoLabelSampleScreen : SampleScreen(
     name = "Session Details Info Label",
@@ -71,7 +71,7 @@ private fun SessionDetailsInfoLabelScreen(navigateUp: () -> Unit, modifier: Modi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SurfaceSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SurfaceSampleScreen.kt
@@ -14,10 +14,10 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import kotlin.math.roundToInt
 
 data object SurfaceSampleScreen : SampleScreen(
@@ -63,7 +63,7 @@ private fun SurfaceScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SwitchSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SwitchSampleScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.SatsSwitch
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object SwitchSampleScreen : SampleScreen(
     name = "Switch",
@@ -70,7 +70,7 @@ private fun LabeledSwitch(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsRewardsLevel
 import com.sats.dna.components.SatsRewardsTag
 import com.sats.dna.components.SatsTag
@@ -19,7 +20,6 @@ import com.sats.dna.components.SatsTagPlaceholder
 import com.sats.dna.components.SatsWorkoutTag
 import com.sats.dna.components.SatsWorkoutTagColor
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object TagsSampleScreen : SampleScreen(
     name = "Tags",
@@ -81,7 +81,7 @@ private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) 
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TextFieldSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TextFieldSampleScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.M3SatsOutlinedTextField
 import com.sats.dna.components.M3SatsTextField
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object TextFieldSampleScreen : SampleScreen(
     name = "Text Field",
@@ -99,7 +99,7 @@ private fun LabeledOutlinedTextField(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TopAppBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TopAppBarSampleScreen.kt
@@ -15,13 +15,13 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.appbar.M3SatsTopAppBar
 import com.sats.dna.components.appbar.SatsLargeTopAppBar
 import com.sats.dna.components.appbar.SatsTopAppBar
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object TopAppBarSampleScreen : SampleScreen(
     name = "Top App Bar",
@@ -98,7 +98,7 @@ private fun Actions() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TrafficLightsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TrafficLightsSampleScreen.kt
@@ -13,11 +13,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.TrafficLight
 import com.sats.dna.components.TrafficLightColor
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object TrafficLightsSampleScreen : SampleScreen(
     name = "Traffic Lights",
@@ -53,7 +53,7 @@ private fun TrafficLightsScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun TrafficLightsScreenPreview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TypographySampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TypographySampleScreen.kt
@@ -23,10 +23,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.SatsVerticalDivider
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object TypographySampleScreen : SampleScreen(
     name = "Typography",
@@ -164,7 +164,7 @@ private fun ParagraphSample(style: TextStyle, modifier: Modifier = Modifier) {
     Text("Lorem ipsum\ndolor sit amet.", modifier, style = style)
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/UpcomingWorkoutListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/UpcomingWorkoutListItemSampleScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
@@ -16,7 +17,6 @@ import com.sats.dna.components.upcomingworkouts.UpcomingWorkoutListItem
 import com.sats.dna.components.upcomingworkouts.WaitingListStatus
 import com.sats.dna.components.upcomingworkouts.WorkoutType
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object UpcomingWorkoutListItemSampleScreen : SampleScreen(
     name = "Upcoming Workout List Item",
@@ -87,7 +87,7 @@ private fun UpcomingWorkoutListItemScreen(navigateUp: () -> Unit, modifier: Modi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/YourMostBookedSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/YourMostBookedSampleScreen.kt
@@ -3,10 +3,10 @@ package com.sats.dna.sample.screens
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.YourMostBookedCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data object YourMostBookedSampleScreen : SampleScreen(
     name = "Your Most Booked",
@@ -29,7 +29,7 @@ private fun YourMostBookedSampleScreen(navigateUp: () -> Unit, modifier: Modifie
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun YourMostBookedSampleScreenPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/AnimatedCheckmark.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/AnimatedCheckmark.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun AnimatedCheckmark(modifier: Modifier = Modifier) {
@@ -91,7 +91,7 @@ private fun DrawScope.drawCircle(
 
 private const val strokeWidth = 2.73f
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun AnimatedCheckIconPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/BrandLogo.kt
@@ -5,11 +5,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.R
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.materialIconTint
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun BrandLogo(
@@ -46,7 +46,7 @@ private fun Brand.fullNameIconPainter() = when (this) {
     Brand.Elixia -> painterResource(R.drawable.ic_elixia)
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ElixiaLetterPreview() {
     SatsTheme {
@@ -60,7 +60,7 @@ private fun ElixiaLetterPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ElixiaFullPreview() {
     SatsTheme {
@@ -75,7 +75,7 @@ private fun ElixiaFullPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsLetterPreview() {
     SatsTheme {
@@ -89,7 +89,7 @@ private fun SatsLetterPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsFullPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/CompletedWorkoutListItem.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.button.LikeButton
 import com.sats.dna.components.icons.WorkoutType
@@ -19,8 +21,6 @@ import com.sats.dna.components.icons.WorkoutTypeIcon
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * Displays a list item for a completed workout.
@@ -146,8 +146,8 @@ private fun WorkoutInfo(
     }
 }
 
-@LightDarkPreview
-@FontSizePreview
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/GxSessionImage.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/GxSessionImage.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import coil.compose.AsyncImage
 import com.sats.dna.R
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun GxSessionImage(
@@ -26,7 +26,7 @@ fun GxSessionImage(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun GxSessionImagePreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/JoinYourFriends.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/JoinYourFriends.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.internal.GxSessionCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun JoinYourFriendsCard(
@@ -31,7 +31,7 @@ fun JoinYourFriendsCard(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun JoinYourFriendsCardPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/Pill.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/Pill.kt
@@ -11,9 +11,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun Pill(
@@ -48,7 +48,7 @@ fun Pill(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PillPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/Placeholders.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/Placeholders.kt
@@ -27,11 +27,11 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun PlaceholderBox(
@@ -95,7 +95,7 @@ private fun rememberTextSize(text: String, style: TextStyle): DpSize {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PlaceholderBoxPreview() {
     SatsTheme {
@@ -116,7 +116,7 @@ private fun PlaceholderBoxPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PlaceholderTextPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/ProfileAvatarImage.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/ProfileAvatarImage.kt
@@ -8,11 +8,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.sats.dna.R
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun ProfileAvatarImage(
@@ -38,7 +38,7 @@ fun ProfileAvatarImagePlaceholder(modifier: Modifier = Modifier) {
     PlaceholderBox(modifier.clip(SatsTheme.shapes.circle))
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ProfileAvatarImagePreview() {
     SatsTheme {
@@ -53,7 +53,7 @@ private fun ProfileAvatarImagePreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ProfileAvatarImagePlaceholderPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsBanner(
@@ -61,7 +61,7 @@ private val SatsBannerAction.composable: @Composable () -> Unit
         }
     }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsBannerPreview() {
     SatsTheme {
@@ -74,7 +74,7 @@ private fun SatsBannerPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsBannerWithActionPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCampaignModule.kt
@@ -12,10 +12,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import coil.compose.AsyncImage
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import com.sats.dna.tooling.PreviewImagePlaceholder
 
 @Composable
@@ -66,7 +66,7 @@ private fun HeroImage(imageUrl: String) {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsCampaignModulePreview() {
     SatsTheme {
@@ -81,7 +81,7 @@ private fun SatsCampaignModulePreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsCampaignWithoutSubtitleModulePreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBadge.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBadge.kt
@@ -11,11 +11,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import com.sats.dna.R
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsChallengeBadge(
@@ -59,7 +59,7 @@ private fun ErrorFallback(contentDescription: String?, modifier: Modifier = Modi
     Image(painterResource(R.drawable.placeholder_challenges), contentDescription, modifier)
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {
@@ -75,7 +75,7 @@ private fun Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun ProgressPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCheckbox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCheckbox.kt
@@ -8,10 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsCheckbox(
@@ -77,7 +77,7 @@ private val fixedColors
         checkmarkColor = SatsTheme.colors2.graphicalElements.selectorFixed.indicator,
     )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BooleanEnabledCheckedPreview() {
     SatsTheme {
@@ -91,7 +91,7 @@ private fun BooleanEnabledCheckedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BooleanEnabledUncheckedPreview() {
     SatsTheme {
@@ -105,7 +105,7 @@ private fun BooleanEnabledUncheckedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BooleanDisabledCheckedPreview() {
     SatsTheme {
@@ -120,7 +120,7 @@ private fun BooleanDisabledCheckedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun BooleanDisabledUncheckedPreview() {
     SatsTheme {
@@ -197,7 +197,7 @@ private fun BooleanDisabledUncheckedFixedColorsPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun TriStateEnabledDefaultPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,
@@ -214,7 +214,7 @@ private fun TriStateEnabledDefaultPreview(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun TriStateDisabledDefaultPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
@@ -16,11 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsFilterChip(
@@ -164,7 +164,7 @@ private fun SatsChipLayout(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsFilterChipPreview() {
     SatsTheme {
@@ -216,7 +216,7 @@ private fun SatsFilterChipPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsInputChipPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsCircularProgressIndicator(
@@ -44,7 +44,7 @@ fun SatsCircularProgressIndicator(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsDivider.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsDivider.kt
@@ -16,10 +16,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsHorizontalDivider(
@@ -71,7 +71,7 @@ private val SatsDividerColor.composeColor: Color
         SatsDividerColor.Alternate -> SatsTheme.colors2.graphicalElements.divider.alternate
     }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsHorizontalDividerPreview() {
     SatsTheme {
@@ -93,7 +93,7 @@ private fun SatsHorizontalDividerPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsVerticalDividerPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
@@ -11,13 +11,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsEmptyStateCard(
@@ -101,7 +101,7 @@ fun SatsEmptyState(
  */
 data class SatsEmptyStateAction(val action: () -> Unit, val label: String)
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsEmptyStateM3Preview() {
     SatsTheme {
@@ -118,7 +118,7 @@ private fun SatsEmptyStateM3Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsEmptyStateM2Preview() {
     SatsTheme {
@@ -135,7 +135,7 @@ private fun SatsEmptyStateM2Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsEmptyStateCardPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
@@ -13,12 +13,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.internal.materialIconTint
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * @param trailingContent trailing content of list item. Consider using [TrailingContent].
@@ -122,7 +122,7 @@ private class DefaultSatsGeneralListItem(
     override val iconColor: Color,
 ) : SatsGeneralListItemColors
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {
@@ -137,7 +137,7 @@ private fun Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WithSubtitle() {
     SatsTheme {
@@ -153,7 +153,7 @@ private fun WithSubtitle() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WithTrailingContentPreview() {
     SatsTheme {
@@ -169,7 +169,7 @@ private fun WithTrailingContentPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WithAdvancedTrailingContentPreview() {
     SatsTheme {
@@ -185,7 +185,7 @@ private fun WithAdvancedTrailingContentPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WithNonDefaultColorsPreview() {
     SatsTheme {
@@ -203,7 +203,7 @@ private fun WithNonDefaultColorsPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WithoutIconPreview() {
     SatsTheme {
@@ -219,7 +219,7 @@ private fun WithoutIconPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsGeneralListItemLoadingPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
@@ -8,9 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.ContentAlpha as M2ContentAlpha
 import androidx.compose.material.LocalContentAlpha as M2LocalContentAlpha
 import androidx.compose.material.LocalContentColor as M2LocalContentColor
@@ -238,7 +238,7 @@ object M3SatsOutlinedTextFieldDefaults {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsOutlinedTextFieldEnabledPreview() {
     SatsTheme {
@@ -252,7 +252,7 @@ private fun SatsOutlinedTextFieldEnabledPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsOutlinedTextFieldDisabledPreview() {
     SatsTheme {
@@ -267,7 +267,7 @@ private fun SatsOutlinedTextFieldDisabledPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun M3SatsOutlinedTextFieldEnabledPreview() {
     SatsTheme {
@@ -282,7 +282,7 @@ private fun M3SatsOutlinedTextFieldEnabledPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun M3SatsOutlinedTextFieldDisabledPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
@@ -4,8 +4,8 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsRadioButton(
@@ -25,7 +25,7 @@ private val colors
         disabledUnselectedColor = SatsTheme.colors2.graphicalElements.selector.unselected.disabled,
     )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledSelectedPreview() {
     SatsTheme {
@@ -35,7 +35,7 @@ private fun EnabledSelectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledUnselectedPreview() {
     SatsTheme {
@@ -45,7 +45,7 @@ private fun EnabledUnselectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledSelectedPreview() {
     SatsTheme {
@@ -55,7 +55,7 @@ private fun DisabledSelectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledUnselectedPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsScaleBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsScaleBar.kt
@@ -12,10 +12,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsScaleBar(
@@ -54,8 +54,8 @@ fun SatsScaleBar(
     }
 }
 
-@LightDarkPreview
-@FontSizePreview
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SatsScaleBarPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
@@ -20,12 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.TrailingContent.Icon
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.components.button.SatsIconButton
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsSearchBar(
@@ -133,7 +133,7 @@ private fun DecorationBox(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {
@@ -149,7 +149,7 @@ private fun Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PreviewWithQuery() {
     SatsTheme {
@@ -165,7 +165,7 @@ private fun PreviewWithQuery() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PreviewWithBackButton() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSwitch.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSwitch.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsSwitch(
@@ -51,7 +51,7 @@ private val colors
         disabledUncheckedIconColor = SatsTheme.colors2.graphicalElements.toggle.unselected.disabled,
     )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledSelectedPreview() {
     SatsTheme {
@@ -61,7 +61,7 @@ private fun EnabledSelectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledUnselectedPreview() {
     SatsTheme {
@@ -71,7 +71,7 @@ private fun EnabledUnselectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledSelectedPreview() {
     SatsTheme {
@@ -81,7 +81,7 @@ private fun DisabledSelectedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledUnselectedPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsTag(
@@ -139,7 +139,7 @@ private fun SatsTagLayout(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsTagPreview() {
     SatsTheme {
@@ -157,7 +157,7 @@ private fun SatsTagPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsRewardsTagPreview() {
     SatsTheme {
@@ -175,7 +175,7 @@ private fun SatsRewardsTagPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsTagPlaceholderPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTextField.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTextField.kt
@@ -10,9 +10,9 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material3.TextField as Material3TextField
 import androidx.compose.material3.TextFieldColors as M3TextFieldColors
 import androidx.compose.material3.TextFieldDefaults as M3TextFieldDefaults
@@ -85,7 +85,7 @@ fun M3SatsTextField(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledMaterial2TextFieldPreview() {
     SatsTheme {
@@ -99,7 +99,7 @@ private fun EnabledMaterial2TextFieldPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledMaterial2TextFieldPreview() {
     SatsTheme {
@@ -114,7 +114,7 @@ private fun DisabledMaterial2TextFieldPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun EnabledMaterial3TextFieldPreview() {
     SatsTheme {
@@ -129,7 +129,7 @@ private fun EnabledMaterial3TextFieldPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun DisabledMaterial3TextFieldPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/TrafficLight.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/TrafficLight.kt
@@ -14,9 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun TrafficLight(color: TrafficLightColor, modifier: Modifier = Modifier) {
@@ -56,7 +56,7 @@ enum class TrafficLightColor {
     Gray,
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun TrafficLightPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/YourMostBookedCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/YourMostBookedCard.kt
@@ -3,9 +3,9 @@ package com.sats.dna.components
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.internal.GxSessionCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun YourMostBookedCard(
@@ -24,7 +24,7 @@ fun YourMostBookedCard(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun YourMostBookedCardPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/LargeTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/LargeTopAppBar.kt
@@ -13,9 +13,9 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,7 +68,7 @@ fun SatsLargeTopAppBar(
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Material3Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/TopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/TopAppBar.kt
@@ -17,10 +17,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.google.accompanist.insets.ui.TopAppBar
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material3.Icon as M3Icon
 import androidx.compose.material3.IconButton as M3IconButton
 import androidx.compose.material3.Text as M3Text
@@ -112,7 +112,7 @@ fun M3SatsTopAppBar(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Material2Preview() {
     SatsTheme {
@@ -138,7 +138,7 @@ private fun Material2Preview() {
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Material3Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/LikeButton.kt
@@ -6,11 +6,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.icons.fistBump
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun LikeButton(
@@ -28,7 +28,7 @@ fun LikeButton(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun LikedPreview() {
     val (isLiked, setIsLiked) = remember { mutableStateOf(true) }
@@ -40,7 +40,7 @@ private fun LikedPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun NotLikedPreview() {
     val (isLiked, setIsLiked) = remember { mutableStateOf(false) }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -23,13 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsButton(
@@ -123,7 +123,7 @@ private fun buttonPadding(isLarge: Boolean): PaddingValues {
     return PaddingValues(horizontal = SatsTheme.spacing.m, vertical.value)
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
@@ -142,7 +142,7 @@ private fun SatsButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) 
     }
 }
 
-@FontSizePreview
+@PreviewFontScale
 @Composable
 private fun SatsButtonFontScalePreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsIconButton(
@@ -156,7 +156,7 @@ private fun animatedPadding(isLarge: Boolean) =
         label = "Padding",
     ).value
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsIconButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
@@ -172,7 +172,7 @@ private fun SatsIconButtonPreview(@PreviewParameter(SatsButtonColorProvider::cla
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsBellIconButtonNoCherryPreview() {
     SatsTheme {
@@ -187,7 +187,7 @@ private fun SatsBellIconButtonNoCherryPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsBellIconButtonWithCherryPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -11,13 +11,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.R
 import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsCard(
@@ -33,7 +33,7 @@ fun SatsCard(
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Material3Preview() {
     SatsTheme {
@@ -67,7 +67,7 @@ private fun Material3Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Material2Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/chip/Chip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/chip/Chip.kt
@@ -6,11 +6,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsChip(label: String, modifier: Modifier = Modifier) {
@@ -29,7 +29,7 @@ fun SatsChip(label: String, modifier: Modifier = Modifier) {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/icons/DefaultInstructorIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/icons/DefaultInstructorIcon.kt
@@ -10,9 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * Displays a default image representing the type of an instructor.
@@ -54,7 +54,7 @@ enum class InstructorType {
     Pt, Gx,
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun GxPreview() {
     SatsTheme {
@@ -64,7 +64,7 @@ private fun GxPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun PtPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/icons/WorkoutTypeIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/icons/WorkoutTypeIcon.kt
@@ -4,11 +4,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * Displays an icon representing a workout type.
@@ -58,7 +58,7 @@ enum class WorkoutType {
     Unknown,
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview(@PreviewParameter(WorkoutTypePreviewProvider::class) workoutType: WorkoutType) {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/internal/GxSessionCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/internal/GxSessionCard.kt
@@ -12,12 +12,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.GxSessionImage
 import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 internal fun GxSessionCard(
@@ -62,7 +62,7 @@ internal fun GxSessionCard(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun GxSessionCardPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/navigation/BottomNavigation.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/navigation/BottomNavigation.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun SatsBottomNavigation(
@@ -99,7 +99,7 @@ data class SatsBottomNavigationItem(
     val hasBadge: Boolean = false,
 )
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/LinearProgressBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/LinearProgressBar.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun LinearProgressBar(
@@ -69,7 +69,7 @@ private fun DrawScope.drawProgress(progress: Float, color: Color) {
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsButton
@@ -21,8 +23,6 @@ import com.sats.dna.components.button.SatsIconButton
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * Protein Bar to display short and non intrusive messages to a user.
@@ -156,7 +156,7 @@ private fun ActionButton(action: SatsProteinBarAction, modifier: Modifier = Modi
     )
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsProteinBarPreview() {
     SatsTheme {
@@ -169,7 +169,7 @@ private fun SatsProteinBarPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsProteinBarInfoPreview() {
     SatsTheme {
@@ -187,7 +187,7 @@ private fun SatsProteinBarInfoPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsProteinBarSuccessPreview() {
     SatsTheme {
@@ -205,7 +205,7 @@ private fun SatsProteinBarSuccessPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsProteinBarWarningPreview() {
     SatsTheme {
@@ -223,7 +223,7 @@ private fun SatsProteinBarWarningPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SatsProteinBarErrorPreview() {
     SatsTheme {
@@ -278,7 +278,7 @@ private fun SatsProteinBarWithDismissAndActionPreview() {
     }
 }
 
-@FontSizePreview
+@PreviewFontScale
 @Composable
 private fun SatsProteinBarFontSizesPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/FriendsBookingStatus.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/FriendsBookingStatus.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -23,7 +24,6 @@ import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.PlaceholderText
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 data class FriendsBookingState(
     val status: FriendsBookingStatus,
@@ -117,7 +117,7 @@ fun FriendsBookingStatusListPlaceholder(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun FriendsBookingListItemPreview(
     @PreviewParameter(FriendsBookingStatusPreviewProvider::class) bookingState: FriendsBookingState,
@@ -144,7 +144,7 @@ private fun FriendsBookingListItemPreview(
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun FriendsBookingListItemPlaceholderPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SessionDetailsInfoLabel.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.PlaceholderText
@@ -20,7 +21,6 @@ import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.LocalContentColor as LocalContentColorM2
 import androidx.compose.material3.LocalContentColor as LocalContentColorM3
 
@@ -165,7 +165,7 @@ fun SessionDetailsInfoLabelPlaceholder(text: String, modifier: Modifier = Modifi
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SessionDetailsInfoSectionPreview() {
     SatsTheme {
@@ -207,7 +207,7 @@ private fun SessionDetailsInfoSectionPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SessionDetailsInfoSectionPlaceholderPreview() {
     SatsTheme {
@@ -217,7 +217,7 @@ private fun SessionDetailsInfoSectionPlaceholderPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SessionDetailsInfoLabelPlaceholderPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/Schedule.kt
@@ -11,13 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.PlaceholderText
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.card.SatsCard
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 fun Schedule(
@@ -148,8 +148,8 @@ private fun ScheduledWorkouts(
     }
 }
 
-@LightDarkPreview
-@FontSizePreview
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SchedulePreview() {
     val schedule = listOf(
@@ -197,7 +197,7 @@ private fun SchedulePreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun SchedulePlaceholderPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutContent.kt
@@ -9,11 +9,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 
 @Composable
 internal fun WorkoutTypeColorIndicator(
@@ -126,7 +126,7 @@ private fun WaitingListStatus(status: WaitingListStatus) {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun TimeAndDurationPreview() {
     SatsTheme {
@@ -140,7 +140,7 @@ private fun TimeAndDurationPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WorkoutInfoPreview() {
     SatsTheme {
@@ -157,7 +157,7 @@ private fun WorkoutInfoPreview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun WorkoutInfoOnWaitingListPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.PlaceholderBox
 import com.sats.dna.components.SatsSurface
@@ -26,8 +28,6 @@ import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.FontSizePreview
-import com.sats.dna.tooling.LightDarkPreview
 
 /**
  * A section for a day of upcoming workouts
@@ -157,8 +157,8 @@ fun UpcomingWorkoutAttendingFriendsLabel(
     }
 }
 
-@LightDarkPreview
-@FontSizePreview
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun UpcomingWorkoutsListPreview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.LocalUseMaterial3
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
-import com.sats.dna.tooling.LightDarkPreview
 import androidx.compose.material.Icon as Material2Icon
 import androidx.compose.material.LocalContentAlpha as Material2LocalContentAlpha
 import androidx.compose.material.LocalContentColor as Material2LocalContentColor
@@ -38,7 +38,7 @@ internal fun materialIconTint(): Color {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun M2Preview() {
     SatsTheme {
@@ -48,7 +48,7 @@ private fun M2Preview() {
     }
 }
 
-@LightDarkPreview
+@PreviewLightDark
 @Composable
 private fun M3Preview() {
     SatsTheme {

--- a/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/tooling/PreviewAnnotations.kt
@@ -1,13 +1,16 @@
 package com.sats.dna.tooling
 
-import android.content.res.Configuration
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 
-@Preview("Light Mode", group = "Theme", uiMode = Configuration.UI_MODE_NIGHT_NO)
-@Preview("Dark Mode", group = "Theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
-annotation class LightDarkPreview
+@Deprecated(
+    message = "Use `PreviewLightDark` from androidx.compose.ui.tooling instead.",
+    replaceWith = ReplaceWith("androidx.compose.ui.tooling.preview.PreviewLightDark"),
+)
+typealias LightDarkPreview = PreviewLightDark
 
-@Preview("Small Font Size (0.75x)", group = "Font Sizes", fontScale = 0.75f)
-@Preview("Large Font Size (1.50x)", group = "Font Sizes", fontScale = 1.5f)
-@Preview("Huge Font Size (2.0x)", group = "Font Sizes", fontScale = 2f)
-annotation class FontSizePreview
+@Deprecated(
+    message = "Use `PreviewFontScale` from androidx.compose.ui.tooling instead.",
+    replaceWith = ReplaceWith("androidx.compose.ui.tooling.preview.PreviewFontScale"),
+)
+typealias FontSizePreview = PreviewFontScale


### PR DESCRIPTION
- Alias the `@LightDarkPreview` and `@FontScalePreview` multi-previews to `@PreviewLightDark` and `@PreviewFontScale` from compose-ui-tooling, respectively. 
- Delete all internal usages of the old annotations.
- The deprecated annotations are kept, but deprecated, to avoid breaking the APIs.