### PR TITLE
NMA-6316: Remove Transparent button color and change Action

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -68,7 +68,6 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                 SatsButtonColor.CleanSecondary,
                 SatsButtonColor.WaitingList,
                 SatsButtonColor.Action,
-                SatsButtonColor.Transparent,
             ).forEach { color ->
                 val backgroundColor = if (color == SatsButtonColor.Clean || color == SatsButtonColor.CleanSecondary) {
                     SatsTheme.colors2.backgrounds.fixed.bg.default
@@ -121,7 +120,7 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                     listOf(
                         SatsButtonColor.Clean,
                         SatsButtonColor.WaitingList,
-                        SatsButtonColor.Transparent,
+                        SatsButtonColor.Action,
                     ).forEach { color ->
                         SatsIconButton(
                             onClick = {},

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/UpcomingWorkoutListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/UpcomingWorkoutListItemSampleScreen.kt
@@ -50,7 +50,7 @@ private fun UpcomingWorkoutListItemScreen(navigateUp: () -> Unit, modifier: Modi
                             SatsButton(
                                 onClick = { },
                                 label = "Unbook",
-                                colors = SatsButtonColor.Transparent,
+                                colors = SatsButtonColor.Action,
                             )
                         },
                         onClick = {},
@@ -75,7 +75,7 @@ private fun UpcomingWorkoutListItemScreen(navigateUp: () -> Unit, modifier: Modi
                             SatsButton(
                                 onClick = { },
                                 label = "Unbook",
-                                colors = SatsButtonColor.Transparent,
+                                colors = SatsButtonColor.Action,
                             )
                         },
                         onClick = {},

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledCard.kt
@@ -73,7 +73,7 @@ private fun CardHeader(title: String, action: SatsTitledCardAction?, modifier: M
                         onClick = action.action,
                         icon = SatsTheme.icons.arrowRight,
                         onClickLabel = action.contentDescription,
-                        colors = SatsButtonColor.Transparent,
+                        colors = SatsButtonColor.Action,
                     )
                 }
             }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButtonColor.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButtonColor.kt
@@ -16,7 +16,6 @@ enum class SatsButtonColor {
     WaitingList,
     WaitingListSecondary,
     Action,
-    Transparent,
 }
 
 @Composable
@@ -56,7 +55,6 @@ internal val SatsButtonColor.backgroundColor: Color
         SatsButtonColor.WaitingList -> SatsTheme.colors2.buttons.waitingListFilled.default.bg
         SatsButtonColor.WaitingListSecondary -> Color.Transparent
         SatsButtonColor.Action -> Color.Transparent
-        SatsButtonColor.Transparent -> Color.Transparent
     }
 
 internal val SatsButtonColor.contentColor: Color
@@ -68,8 +66,7 @@ internal val SatsButtonColor.contentColor: Color
         SatsButtonColor.CleanSecondary -> SatsTheme.colors2.buttons.cleanSecondary.default.fg
         SatsButtonColor.WaitingList -> SatsTheme.colors2.buttons.waitingListFilled.default.fg
         SatsButtonColor.WaitingListSecondary -> SatsTheme.colors2.buttons.waitingListOutlined.default
-        SatsButtonColor.Action -> SatsTheme.colors.action.default
-        SatsButtonColor.Transparent -> SatsTheme.colors2.buttons.action.default
+        SatsButtonColor.Action -> SatsTheme.colors2.buttons.action.default
     }
 
 internal val SatsButtonColor.disabledBackgroundColor: Color
@@ -82,7 +79,6 @@ internal val SatsButtonColor.disabledBackgroundColor: Color
         SatsButtonColor.WaitingList -> SatsTheme.colors2.buttons.waitingListFilled.disabled.bg
         SatsButtonColor.WaitingListSecondary -> Color.Transparent
         SatsButtonColor.Action -> Color.Transparent
-        SatsButtonColor.Transparent -> Color.Transparent
     }
 
 internal val SatsButtonColor.disabledContentColor: Color
@@ -94,6 +90,5 @@ internal val SatsButtonColor.disabledContentColor: Color
         SatsButtonColor.CleanSecondary -> SatsTheme.colors2.buttons.cleanSecondary.disabled.fg
         SatsButtonColor.WaitingList -> SatsTheme.colors2.buttons.waitingListFilled.disabled.fg
         SatsButtonColor.WaitingListSecondary -> SatsTheme.colors2.buttons.waitingListOutlined.disabled
-        SatsButtonColor.Action -> SatsTheme.colors.action.disabled
-        SatsButtonColor.Transparent -> SatsTheme.colors2.buttons.action.disabled
+        SatsButtonColor.Action -> SatsTheme.colors2.buttons.action.disabled
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
@@ -152,7 +152,7 @@ private fun ActionButton(action: SatsProteinBarAction, modifier: Modifier = Modi
         onClick = action.action,
         label = action.label,
         modifier = modifier,
-        colors = SatsButtonColor.Transparent,
+        colors = SatsButtonColor.Action,
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/UpcomingWorkoutListItem.kt
@@ -175,7 +175,7 @@ private fun UpcomingWorkoutsListPreview() {
                             SatsButton(
                                 onClick = { },
                                 label = "Unbook",
-                                colors = SatsButtonColor.Transparent,
+                                colors = SatsButtonColor.Action,
                             )
                         },
                         friendsAttending = {


### PR DESCRIPTION
The Transparent button color was actually colored like Action, so it's been renamed to Action. And then we just removed the old Action color, as that was using the wrong (blue) color of links.

![image](https://github.com/sats-group/sats-dna-android/assets/386122/b2b9f0fb-2030-4cbf-b3eb-82f5ec023a3d)

![image](https://github.com/sats-group/sats-dna-android/assets/386122/e0fcb63e-8e85-43d0-9d8d-4dc85c5b4d47)
