### PR TITLE
NMA-6302: New Challenge Card + updated Tags

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -12,6 +12,7 @@ import com.sats.dna.sample.screens.CampaignModuleSampleScreen
 import com.sats.dna.sample.screens.CardSampleScreen
 import com.sats.dna.sample.screens.ChallengeBackgroundSampleScreen
 import com.sats.dna.sample.screens.ChallengeBadgeSampleScreen
+import com.sats.dna.sample.screens.ChallengeCardSampleScreen
 import com.sats.dna.sample.screens.CheckboxSampleScreen
 import com.sats.dna.sample.screens.ChipsSampleScreen
 import com.sats.dna.sample.screens.Colors2SampleScreen
@@ -60,6 +61,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
         CardSampleScreen.navScreen(navController)
         ChallengeBackgroundSampleScreen.navScreen(navController)
         ChallengeBadgeSampleScreen.navScreen(navController)
+        ChallengeCardSampleScreen.navScreen(navController)
         CheckboxSampleScreen.navScreen(navController)
         ChipsSampleScreen.navScreen(navController)
         CompletedWorkoutListItemSampleScreen.navScreen(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import com.sats.dna.sample.screens.CampaignModuleSampleScreen
 import com.sats.dna.sample.screens.CardSampleScreen
 import com.sats.dna.sample.screens.ChallengeBackgroundSampleScreen
 import com.sats.dna.sample.screens.ChallengeBadgeSampleScreen
+import com.sats.dna.sample.screens.ChallengeCardSampleScreen
 import com.sats.dna.sample.screens.CheckboxSampleScreen
 import com.sats.dna.sample.screens.ChipsSampleScreen
 import com.sats.dna.sample.screens.Colors2SampleScreen
@@ -77,6 +78,7 @@ internal fun HomeScreen(navController: NavController) {
             CardSampleScreen.HomeListItem(navController)
             ChallengeBackgroundSampleScreen.HomeListItem(navController)
             ChallengeBadgeSampleScreen.HomeListItem(navController)
+            ChallengeCardSampleScreen.HomeListItem(navController)
             CheckboxSampleScreen.HomeListItem(navController)
             ChipsSampleScreen.HomeListItem(navController)
             CompletedWorkoutListItemSampleScreen.HomeListItem(navController)

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
@@ -1,0 +1,89 @@
+package com.sats.dna.sample.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.sats.dna.components.card.ChallengeCard
+import com.sats.dna.components.card.ChallengeCardState
+import com.sats.dna.theme.SatsTheme
+
+data object ChallengeCardSampleScreen : SampleScreen(
+    name = "Challenge Card",
+    route = "/components/challenge-card",
+    screen = { ChallengeCardScreen(it::navigateUp) },
+)
+
+@Composable
+private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
+    ComponentScreen("Challenge Card Screen", navigateUp, modifier) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(SatsTheme.spacing.m),
+            verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            ChallengeCard(
+                ChallengeCardState.AvailableChallengeCard(
+                    imageUrl = null,
+                    title = "STREAK WEEK",
+                    subtitle = "Workout for 7 consecutive days",
+                    buttonText = "Join",
+                    tagText = "23 days left",
+                    onCardClick = {},
+                    onJoinClick = {},
+                ),
+                modifier = Modifier
+                    .height(255.dp)
+                    .width(176.dp),
+            )
+
+            ChallengeCard(
+                ChallengeCardState.JoinedChallengeCard(
+                    imageUrl = null,
+                    title = "STREAK WEEK",
+                    tagText = "23 days left!",
+                    progress = 0.14f,
+                    statusText = "1 out of 7 workouts",
+                    onCardClick = {},
+                ),
+                modifier = Modifier
+                    .height(255.dp)
+                    .width(176.dp),
+            )
+
+            ChallengeCard(
+                ChallengeCardState.DisabledChallengeCard(
+                    imageUrl = null,
+                    title = "STREAK WEEK",
+                    statusText = "Not completed",
+                    onCardClick = {},
+                    onDeleteClick = {},
+                ),
+                modifier = Modifier
+                    .height(255.dp)
+                    .width(176.dp),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun CampaignModulesScreenPreview() {
+    SatsTheme {
+        ChallengeCardScreen(navigateUp = {})
+    }
+}

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
@@ -36,7 +36,7 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             ChallengeCard(
-                ChallengeCardState.AvailableChallengeCard(
+                ChallengeCardState.Available(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     subtitle = "Workout for 7 consecutive days",
@@ -51,7 +51,7 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
             )
 
             ChallengeCard(
-                ChallengeCardState.JoinedChallengeCard(
+                ChallengeCardState.Joined(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     tagText = "23 days left!",
@@ -65,7 +65,7 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
             )
 
             ChallengeCard(
-                ChallengeCardState.DisabledChallengeCard(
+                ChallengeCardState.Disabled(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     statusText = "Not completed",

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TagsSampleScreen.kt
@@ -17,6 +17,8 @@ import com.sats.dna.components.SatsRewardsTag
 import com.sats.dna.components.SatsTag
 import com.sats.dna.components.SatsTagColor
 import com.sats.dna.components.SatsTagPlaceholder
+import com.sats.dna.components.SatsTagShape
+import com.sats.dna.components.SatsTagSize
 import com.sats.dna.components.SatsWorkoutTag
 import com.sats.dna.components.SatsWorkoutTagColor
 import com.sats.dna.theme.SatsTheme
@@ -39,9 +41,14 @@ private fun TagsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxl),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Section("Filter Tags") {
+            Section("Tags") {
                 SatsTagColor.entries.forEach { color ->
-                    SatsTag("$color", color = color)
+                    SatsTag("$color SMALL", color = color)
+                    SatsTag("$color BASIC", color = color, size = SatsTagSize.Basic)
+                    SatsTag("$color LEFT SMALL", color = color, shape = SatsTagShape.Left)
+                    SatsTag("$color RIGHT SMALL", color = color, shape = SatsTagShape.Right)
+                    SatsTag("$color LEFT BASIC", color = color, shape = SatsTagShape.Left, size = SatsTagSize.Basic)
+                    SatsTag("$color RIGHT BASIC", color = color, shape = SatsTagShape.Right, size = SatsTagSize.Basic)
                 }
             }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/GreyScaleModifier.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/GreyScaleModifier.kt
@@ -1,0 +1,24 @@
+package com.sats.dna
+
+import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+
+class GreyScaleModifier : DrawModifier {
+    override fun ContentDrawScope.draw() {
+        val saturationMatrix = ColorMatrix().apply { setToSaturation(0f) }
+        val paint = Paint().apply {
+            colorFilter = ColorFilter.colorMatrix(saturationMatrix)
+        }
+
+        drawIntoCanvas {
+            it.saveLayer(Rect(0f, 0f, size.width, size.height), paint)
+            drawContent()
+            it.restore()
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
@@ -6,16 +6,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.DrawModifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.drawscope.ContentDrawScope
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.sats.dna.GreyScaleModifier
 import com.sats.dna.R
 import com.sats.dna.theme.SatsTheme
 
@@ -44,21 +40,6 @@ fun SatsChallengeBackground(modifier: Modifier = Modifier, isEnabled: Boolean = 
             )
 
             content()
-        }
-    }
-}
-
-class GreyScaleModifier : DrawModifier {
-    override fun ContentDrawScope.draw() {
-        val saturationMatrix = ColorMatrix().apply { setToSaturation(0f) }
-        val paint = Paint().apply {
-            colorFilter = ColorFilter.colorMatrix(saturationMatrix)
-        }
-
-        drawIntoCanvas {
-            it.saveLayer(Rect(0f, 0f, size.width, size.height), paint)
-            drawContent()
-            it.restore()
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
@@ -6,6 +6,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -13,20 +20,49 @@ import com.sats.dna.R
 import com.sats.dna.theme.SatsTheme
 
 @Composable
-fun SatsChallengeBackground(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-    SatsSurface(modifier, color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+fun SatsChallengeBackground(modifier: Modifier = Modifier, isEnabled: Boolean = true, content: @Composable () -> Unit) {
+    SatsSurface(
+        modifier = if (!isEnabled) {
+            modifier.greyScale()
+        } else {
+            modifier
+        },
+        color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true,
+    ) {
         Box {
             Image(
                 painter = painterResource(R.drawable.challenge_background_top),
                 contentDescription = null,
                 modifier = Modifier.fillMaxWidth(),
                 contentScale = ContentScale.FillBounds,
+                colorFilter = if (!isEnabled) {
+                    ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
+                } else {
+                    null
+                },
             )
 
             content()
         }
     }
 }
+
+class GreyScaleModifier : DrawModifier {
+    override fun ContentDrawScope.draw() {
+        val saturationMatrix = ColorMatrix().apply { setToSaturation(0f) }
+        val paint = Paint().apply {
+            colorFilter = ColorFilter.colorMatrix(saturationMatrix)
+        }
+
+        drawIntoCanvas {
+            it.saveLayer(Rect(0f, 0f, size.width, size.height), paint)
+            drawContent()
+            it.restore()
+        }
+    }
+}
+
+fun Modifier.greyScale() = this.then(GreyScaleModifier())
 
 @Preview
 @Preview(device = "spec:id=reference_tablet,shape=Normal,width=1280,height=800,unit=dp,dpi=240")

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
@@ -27,7 +27,8 @@ fun SatsChallengeBackground(modifier: Modifier = Modifier, isEnabled: Boolean = 
         } else {
             modifier
         },
-        color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true,
+        color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default,
+        useMaterial3 = true,
     ) {
         Box {
             Image(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
@@ -2,12 +2,16 @@ package com.sats.dna.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import com.sats.dna.internal.MaterialText
 import com.sats.dna.theme.SatsTheme
 
@@ -16,6 +20,8 @@ fun SatsTag(
     text: String,
     modifier: Modifier = Modifier,
     color: SatsTagColor = SatsTagColor.Primary,
+    size: SatsTagSize = SatsTagSize.Small,
+    shape: SatsTagShape = SatsTagShape.Default,
 ) {
     val backgroundColor = when (color) {
         SatsTagColor.Primary -> SatsTheme.colors2.graphicalElements.tags.primary.bg
@@ -29,11 +35,43 @@ fun SatsTag(
         SatsTagColor.Featured -> SatsTheme.colors2.graphicalElements.tags.featured.fg
     }
 
-    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+    val paddingValues = when (size) {
+        SatsTagSize.Small -> PaddingValues(vertical = SatsTheme.spacing.xxs, horizontal = SatsTheme.spacing.s)
+        SatsTagSize.Basic -> PaddingValues(vertical = SatsTheme.spacing.xs, horizontal = SatsTheme.spacing.s)
+    }
+
+    val cornerShape = when (shape) {
+        SatsTagShape.Default -> SatsTheme.shapes.roundedCorners.extraSmall
+        SatsTagShape.Left -> SatsTheme.shapes.roundedCorners.extraSmall.copy(
+            topStart = CornerSize(0.dp),
+            bottomStart = CornerSize(0.dp),
+        )
+        SatsTagShape.Right -> SatsTheme.shapes.roundedCorners.extraSmall.copy(
+            topEnd = CornerSize(0.dp),
+            bottomEnd = CornerSize(0.dp),
+        )
+    }
+
+    SatsTagLayout(
+        text,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        cornerShape = cornerShape,
+        paddingValues = paddingValues,
+        modifier = modifier,
+    )
 }
 
 enum class SatsTagColor {
     Primary, Secondary, Featured,
+}
+
+enum class SatsTagSize {
+    Small, Basic,
+}
+
+enum class SatsTagShape {
+    Default, Left, Right,
 }
 
 @Composable
@@ -62,7 +100,21 @@ fun SatsRewardsTag(
         SatsRewardsLevel.Platinum -> "PLATINUM"
     }
 
-    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+    val shape = SatsTheme.shapes.roundedCorners.extraSmall
+
+    val paddingValues = PaddingValues(
+        horizontal = SatsTheme.spacing.s,
+        vertical = SatsTheme.spacing.xxs,
+    )
+
+    SatsTagLayout(
+        text = text,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        cornerShape = shape,
+        paddingValues = paddingValues,
+        modifier = modifier,
+    )
 }
 
 enum class SatsRewardsLevel {
@@ -93,7 +145,21 @@ fun SatsWorkoutTag(
             SatsTheme.colors2.graphicalElements.workouts.other.fg
     }
 
-    SatsTagLayout(text, backgroundColor = backgroundColor, contentColor = contentColor, modifier)
+    val shape = SatsTheme.shapes.roundedCorners.extraSmall
+
+    val paddingValues = PaddingValues(
+        horizontal = SatsTheme.spacing.s,
+        vertical = SatsTheme.spacing.xxs,
+    )
+
+    SatsTagLayout(
+        text = text,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        cornerShape = shape,
+        paddingValues = paddingValues,
+        modifier = modifier,
+    )
 }
 
 enum class SatsWorkoutTagColor {
@@ -122,18 +188,19 @@ private fun SatsTagLayout(
     backgroundColor: Color,
     contentColor: Color,
     modifier: Modifier = Modifier,
+    cornerShape: Shape,
+    paddingValues: PaddingValues,
 ) {
     SatsSurface(
         modifier = modifier,
-        shape = SatsTheme.shapes.roundedCorners.extraSmall,
+        shape = cornerShape,
         color = backgroundColor,
         contentColor = contentColor,
     ) {
         MaterialText(
             text = text.uppercase(),
             modifier = Modifier.padding(
-                horizontal = SatsTheme.spacing.s,
-                vertical = SatsTheme.spacing.xxs,
+                paddingValues,
             ),
         )
     }
@@ -141,7 +208,7 @@ private fun SatsTagLayout(
 
 @PreviewLightDark
 @Composable
-private fun SatsTagPreview() {
+private fun SmallSatsTagPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             Column(
@@ -151,6 +218,96 @@ private fun SatsTagPreview() {
             ) {
                 SatsTagColor.entries.forEach { color ->
                     SatsTag("$color", color = color)
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun BasicSatsTagPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color, size = SatsTagSize.Basic, shape = SatsTagShape.Default)
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SmallLeftAlignedSatsTagPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color, size = SatsTagSize.Small, shape = SatsTagShape.Left)
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun BasicLeftAlignedSatsTagPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color, size = SatsTagSize.Basic, shape = SatsTagShape.Left)
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SmallRightAlignedSatsTagPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color, size = SatsTagSize.Small, shape = SatsTagShape.Right)
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun BasicRightAlignedSatsTagPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                SatsTagColor.entries.forEach { color ->
+                    SatsTag("$color", color = color, size = SatsTagSize.Basic, shape = SatsTagShape.Right)
                 }
             }
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
@@ -42,7 +42,7 @@ import com.sats.dna.theme.SatsTheme
 @Composable
 fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = Modifier) {
     when (challengeCardState) {
-        is ChallengeCardState.AvailableChallengeCard -> {
+        is ChallengeCardState.Available -> {
             AvailableChallengeCard(
                 imageUrl = challengeCardState.imageUrl,
                 title = challengeCardState.title,
@@ -55,7 +55,7 @@ fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = M
             )
         }
 
-        is ChallengeCardState.JoinedChallengeCard -> {
+        is ChallengeCardState.Joined -> {
             JoinedChallengeCard(
                 imageUrl = challengeCardState.imageUrl,
                 title = challengeCardState.title,
@@ -67,7 +67,7 @@ fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = M
             )
         }
 
-        is ChallengeCardState.DisabledChallengeCard -> {
+        is ChallengeCardState.Disabled -> {
             DisabledChallengeCard(
                 imageUrl = challengeCardState.imageUrl,
                 title = challengeCardState.title,
@@ -81,7 +81,7 @@ fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = M
 }
 
 sealed interface ChallengeCardState {
-    class AvailableChallengeCard(
+    class Available(
         val imageUrl: String?,
         val title: String,
         val subtitle: String,
@@ -92,7 +92,7 @@ sealed interface ChallengeCardState {
         val modifier: Modifier = Modifier,
     ) : ChallengeCardState
 
-    class JoinedChallengeCard(
+    class Joined(
         val imageUrl: String?,
         val title: String,
         val tagText: String,
@@ -102,7 +102,7 @@ sealed interface ChallengeCardState {
         val modifier: Modifier = Modifier,
     ) : ChallengeCardState
 
-    class DisabledChallengeCard(
+    class Disabled(
         val imageUrl: String?,
         val title: String,
         val statusText: String,
@@ -339,7 +339,7 @@ private fun ErrorFallback(contentDescription: String?, modifier: Modifier = Modi
 private fun JoinChallengeCardPreview() {
     SatsTheme {
         ChallengeCard(
-            ChallengeCardState.AvailableChallengeCard(
+            ChallengeCardState.Available(
                 imageUrl = null,
                 title = "STREAK WEEK",
                 subtitle = "Workout for 7 consecutive days",
@@ -360,7 +360,7 @@ private fun JoinChallengeCardPreview() {
 private fun JoinedChallengeCardPreview() {
     SatsTheme {
         ChallengeCard(
-            ChallengeCardState.JoinedChallengeCard(
+            ChallengeCardState.Joined(
                 imageUrl = null,
                 title = "STREAK WEEK",
                 tagText = "23 days left!",
@@ -380,7 +380,7 @@ private fun JoinedChallengeCardPreview() {
 private fun DisabledChallengeCardPreview() {
     SatsTheme {
         ChallengeCard(
-            ChallengeCardState.DisabledChallengeCard(
+            ChallengeCardState.Disabled(
                 imageUrl = null,
                 title = "STREAK WEEK",
                 statusText = "Not completed",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
@@ -1,6 +1,5 @@
 package com.sats.dna.components.card
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,16 +19,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
 import com.sats.dna.LocalUseMaterial3
-import com.sats.dna.R
 import com.sats.dna.components.SatsChallengeBackground
-import com.sats.dna.components.SatsPlaceholderBox
+import com.sats.dna.components.SatsChallengeBadge
 import com.sats.dna.components.SatsTag
 import com.sats.dna.components.SatsTagColor
 import com.sats.dna.components.SatsTagShape
@@ -40,40 +35,40 @@ import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
 
 @Composable
-fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = Modifier) {
-    when (challengeCardState) {
+fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
+    when (state) {
         is ChallengeCardState.Available -> {
             AvailableChallengeCard(
-                imageUrl = challengeCardState.imageUrl,
-                title = challengeCardState.title,
-                subtitle = challengeCardState.subtitle,
-                tagText = challengeCardState.tagText,
-                buttonText = challengeCardState.buttonText,
-                onCardClick = challengeCardState.onCardClick,
-                onJoinClick = challengeCardState.onJoinClick,
+                imageUrl = state.imageUrl,
+                title = state.title,
+                subtitle = state.subtitle,
+                tagText = state.tagText,
+                buttonText = state.buttonText,
+                onCardClick = state.onCardClick,
+                onJoinClick = state.onJoinClick,
                 modifier = modifier,
             )
         }
 
         is ChallengeCardState.Joined -> {
             JoinedChallengeCard(
-                imageUrl = challengeCardState.imageUrl,
-                title = challengeCardState.title,
-                tagText = challengeCardState.tagText,
-                progress = challengeCardState.progress,
-                statusText = challengeCardState.statusText,
-                onCardClick = challengeCardState.onCardClick,
+                imageUrl = state.imageUrl,
+                title = state.title,
+                tagText = state.tagText,
+                progress = state.progress,
+                statusText = state.statusText,
+                onCardClick = state.onCardClick,
                 modifier = modifier,
             )
         }
 
         is ChallengeCardState.Disabled -> {
             DisabledChallengeCard(
-                imageUrl = challengeCardState.imageUrl,
-                title = challengeCardState.title,
-                statusText = challengeCardState.statusText,
-                onCardClick = challengeCardState.onCardClick,
-                onDeleteClick = challengeCardState.onDeleteClick,
+                imageUrl = state.imageUrl,
+                title = state.title,
+                statusText = state.statusText,
+                onCardClick = state.onCardClick,
+                onDeleteClick = state.onDeleteClick,
                 modifier = modifier,
             )
         }
@@ -157,17 +152,14 @@ private fun ChallengeCardLayout(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs, Alignment.CenterVertically),
                 ) {
-                    SubcomposeAsyncImage(
+                    SatsChallengeBadge(
                         modifier = Modifier
                             .padding(top = SatsTheme.spacing.m, bottom = SatsTheme.spacing.xxs)
                             .size(75.dp)
                             .aspectRatio(1f)
                             .clip(SatsTheme.shapes.circle),
-                        model = imageUrl,
+                        imageUrl = imageUrl,
                         contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        loading = { LoadingPlaceholder(Modifier.fillMaxSize()) },
-                        error = { ErrorFallback(contentDescription, Modifier.fillMaxSize()) },
                     )
 
                     Text(
@@ -199,7 +191,7 @@ private fun ChallengeCardLayout(
 }
 
 @Composable
-fun AvailableChallengeCard(
+private fun AvailableChallengeCard(
     imageUrl: String?,
     title: String,
     subtitle: String,
@@ -234,7 +226,7 @@ fun AvailableChallengeCard(
 }
 
 @Composable
-fun JoinedChallengeCard(
+private fun JoinedChallengeCard(
     imageUrl: String?,
     title: String,
     tagText: String,
@@ -269,7 +261,7 @@ fun JoinedChallengeCard(
 }
 
 @Composable
-fun DisabledChallengeCard(
+private fun DisabledChallengeCard(
     imageUrl: String?,
     title: String,
     statusText: String,
@@ -322,16 +314,6 @@ private fun ChallengeCardProgress(progress: Float, progressText: String, modifie
             textAlign = TextAlign.Center,
         )
     }
-}
-
-@Composable
-private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
-    SatsPlaceholderBox(modifier)
-}
-
-@Composable
-private fun ErrorFallback(contentDescription: String?, modifier: Modifier = Modifier) {
-    Image(painterResource(R.drawable.placeholder_challenges), contentDescription, modifier)
 }
 
 @PreviewLightDark

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
@@ -1,0 +1,395 @@
+package com.sats.dna.components.card
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import com.sats.dna.R
+import com.sats.dna.components.ChallengeBackground
+import com.sats.dna.components.LocalUseMaterial3
+import com.sats.dna.components.PlaceholderBox
+import com.sats.dna.components.SatsTag
+import com.sats.dna.components.SatsTagColor
+import com.sats.dna.components.SatsTagShape
+import com.sats.dna.components.button.SatsButton
+import com.sats.dna.components.button.SatsButtonColor
+import com.sats.dna.components.progressbar.SatsLinearProgressBar
+import com.sats.dna.internal.MaterialIcon
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun ChallengeCard(challengeCardState: ChallengeCardState, modifier: Modifier = Modifier) {
+    when (challengeCardState) {
+        is ChallengeCardState.AvailableChallengeCard -> {
+            AvailableChallengeCard(
+                imageUrl = challengeCardState.imageUrl,
+                title = challengeCardState.title,
+                subtitle = challengeCardState.subtitle,
+                tagText = challengeCardState.tagText,
+                buttonText = challengeCardState.buttonText,
+                onCardClick = challengeCardState.onCardClick,
+                onJoinClick = challengeCardState.onJoinClick,
+                modifier = modifier,
+            )
+        }
+
+        is ChallengeCardState.JoinedChallengeCard -> {
+            JoinedChallengeCard(
+                imageUrl = challengeCardState.imageUrl,
+                title = challengeCardState.title,
+                tagText = challengeCardState.tagText,
+                progress = challengeCardState.progress,
+                statusText = challengeCardState.statusText,
+                onCardClick = challengeCardState.onCardClick,
+                modifier = modifier,
+            )
+        }
+
+        is ChallengeCardState.DisabledChallengeCard -> {
+            DisabledChallengeCard(
+                imageUrl = challengeCardState.imageUrl,
+                title = challengeCardState.title,
+                statusText = challengeCardState.statusText,
+                onCardClick = challengeCardState.onCardClick,
+                onDeleteClick = challengeCardState.onDeleteClick,
+                modifier = modifier,
+            )
+        }
+    }
+}
+
+sealed interface ChallengeCardState {
+    class AvailableChallengeCard(
+        val imageUrl: String?,
+        val title: String,
+        val subtitle: String,
+        val tagText: String,
+        val buttonText: String,
+        val onCardClick: () -> Unit,
+        val onJoinClick: () -> Unit,
+        val modifier: Modifier = Modifier,
+    ) : ChallengeCardState
+
+    class JoinedChallengeCard(
+        val imageUrl: String?,
+        val title: String,
+        val tagText: String,
+        val progress: Float,
+        val statusText: String,
+        val onCardClick: () -> Unit,
+        val modifier: Modifier = Modifier,
+    ) : ChallengeCardState
+
+    class DisabledChallengeCard(
+        val imageUrl: String?,
+        val title: String,
+        val statusText: String,
+        val onCardClick: () -> Unit,
+        val onDeleteClick: () -> Unit,
+        val modifier: Modifier = Modifier,
+    ) : ChallengeCardState
+}
+
+@Composable
+private fun ChallengeCardLayout(
+    imageUrl: String?,
+    title: String,
+    onCardClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    subtitle: String? = null,
+    tag: @Composable (() -> Unit?)? = null,
+    deleteButton: @Composable (() -> Unit?)? = null,
+    bottomContent: @Composable (() -> Unit?)? = null,
+) {
+    CompositionLocalProvider(LocalUseMaterial3 provides true) {
+        ChallengeBackground(isEnabled = isEnabled, modifier = modifier.height(IntrinsicSize.Min)) {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .clickable(onClick = onCardClick),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.SpaceBetween,
+            ) {
+                tag?.let {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = SatsTheme.spacing.xs),
+                        contentAlignment = Alignment.TopStart,
+                    ) {
+                        tag()
+                    }
+                }
+
+                deleteButton?.let {
+                    Box(
+                        Modifier
+                            .fillMaxWidth(),
+                        contentAlignment = Alignment.TopEnd,
+                    ) {
+                        deleteButton()
+                    }
+                }
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xxs, Alignment.CenterVertically),
+                ) {
+                    SubcomposeAsyncImage(
+                        modifier = Modifier
+                            .padding(top = SatsTheme.spacing.m, bottom = SatsTheme.spacing.xxs)
+                            .size(75.dp)
+                            .aspectRatio(1f)
+                            .clip(SatsTheme.shapes.circle),
+                        model = imageUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        loading = { LoadingPlaceholder(Modifier.fillMaxSize()) },
+                        error = { ErrorFallback(contentDescription, Modifier.fillMaxSize()) },
+                    )
+
+                    Text(
+                        text = title,
+                        style = SatsTheme.typography.satsHeadlineEmphasis.large,
+                        textAlign = TextAlign.Center,
+                    )
+                    subtitle?.let {
+                        Text(
+                            text = subtitle,
+                            style = SatsTheme.typography.normal.small,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+                bottomContent?.let {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = SatsTheme.spacing.xs),
+                        contentAlignment = Alignment.BottomCenter,
+                    ) {
+                        bottomContent()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AvailableChallengeCard(
+    imageUrl: String?,
+    title: String,
+    subtitle: String,
+    tagText: String,
+    buttonText: String,
+    onCardClick: () -> Unit,
+    onJoinClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ChallengeCardLayout(
+        imageUrl = imageUrl,
+        title = title,
+        subtitle = subtitle,
+        onCardClick = onCardClick,
+        modifier = modifier,
+        tag = {
+            SatsTag(
+                text = tagText,
+                color = SatsTagColor.Featured,
+                shape = SatsTagShape.Left,
+            )
+        },
+        bottomContent = {
+            SatsButton(
+                onClick = onJoinClick,
+                label = buttonText,
+                colors = SatsButtonColor.Clean,
+                modifier = Modifier.padding(bottom = SatsTheme.spacing.m),
+            )
+        },
+    )
+}
+
+@Composable
+fun JoinedChallengeCard(
+    imageUrl: String?,
+    title: String,
+    tagText: String,
+    progress: Float,
+    statusText: String,
+    onCardClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ChallengeCardLayout(
+        modifier = modifier,
+        imageUrl = imageUrl,
+        title = title,
+        onCardClick = onCardClick,
+        tag = {
+            SatsTag(
+                text = tagText,
+                color = SatsTagColor.Featured,
+                shape = SatsTagShape.Left,
+            )
+        },
+        bottomContent = {
+            ChallengeCardProgress(
+                progress = progress,
+                progressText = statusText,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = SatsTheme.spacing.m),
+            )
+        },
+
+    )
+}
+
+@Composable
+fun DisabledChallengeCard(
+    imageUrl: String?,
+    title: String,
+    statusText: String,
+    onCardClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ChallengeCardLayout(
+        modifier = modifier,
+        imageUrl = imageUrl,
+        title = title,
+        onCardClick = onCardClick,
+        isEnabled = false,
+        deleteButton = {
+            IconButton(onClick = onDeleteClick) {
+                MaterialIcon(
+                    painter = SatsTheme.icons.delete,
+                    contentDescription = null,
+                    tint = SatsTheme.colors2.graphicalElements.icons.fixed,
+                )
+            }
+        },
+        bottomContent = {
+            Text(
+                text = statusText,
+                style = SatsTheme.typography.normal.small,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = SatsTheme.spacing.l, bottom = SatsTheme.spacing.m),
+            )
+        },
+    )
+}
+
+@Composable
+private fun ChallengeCardProgress(progress: Float, progressText: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        SatsLinearProgressBar(
+            progress = progress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SatsTheme.spacing.s),
+        )
+        Text(
+            text = progressText,
+            style = SatsTheme.typography.normal.small,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
+    PlaceholderBox(modifier)
+}
+
+@Composable
+private fun ErrorFallback(contentDescription: String?, modifier: Modifier = Modifier) {
+    Image(painterResource(R.drawable.placeholder_challenges), contentDescription, modifier)
+}
+
+@PreviewLightDark
+@Composable
+private fun JoinChallengeCardPreview() {
+    SatsTheme {
+        ChallengeCard(
+            ChallengeCardState.AvailableChallengeCard(
+                imageUrl = null,
+                title = "STREAK WEEK",
+                subtitle = "Workout for 7 consecutive days",
+                buttonText = "Join",
+                tagText = "23 days left",
+                onCardClick = {},
+                onJoinClick = {},
+            ),
+            modifier = Modifier
+                .height(255.dp)
+                .width(176.dp),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun JoinedChallengeCardPreview() {
+    SatsTheme {
+        ChallengeCard(
+            ChallengeCardState.JoinedChallengeCard(
+                imageUrl = null,
+                title = "STREAK WEEK",
+                tagText = "23 days left!",
+                progress = 0.14f,
+                statusText = "1 out of 7 workouts",
+                onCardClick = {},
+            ),
+            modifier = Modifier
+                .height(255.dp)
+                .width(176.dp),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DisabledChallengeCardPreview() {
+    SatsTheme {
+        ChallengeCard(
+            ChallengeCardState.DisabledChallengeCard(
+                imageUrl = null,
+                title = "STREAK WEEK",
+                statusText = "Not completed",
+                onCardClick = {},
+                onDeleteClick = {},
+            ),
+            modifier = Modifier
+                .height(255.dp)
+                .width(176.dp),
+        )
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
+import com.sats.dna.LocalUseMaterial3
 import com.sats.dna.R
-import com.sats.dna.components.ChallengeBackground
-import com.sats.dna.components.LocalUseMaterial3
-import com.sats.dna.components.PlaceholderBox
+import com.sats.dna.components.SatsChallengeBackground
+import com.sats.dna.components.SatsPlaceholderBox
 import com.sats.dna.components.SatsTag
 import com.sats.dna.components.SatsTagColor
 import com.sats.dna.components.SatsTagShape
@@ -125,7 +125,7 @@ private fun ChallengeCardLayout(
     bottomContent: @Composable (() -> Unit?)? = null,
 ) {
     CompositionLocalProvider(LocalUseMaterial3 provides true) {
-        ChallengeBackground(isEnabled = isEnabled, modifier = modifier.height(IntrinsicSize.Min)) {
+        SatsChallengeBackground(isEnabled = isEnabled, modifier = modifier.height(IntrinsicSize.Min)) {
             Column(
                 Modifier
                     .fillMaxSize()
@@ -326,7 +326,7 @@ private fun ChallengeCardProgress(progress: Float, progressText: String, modifie
 
 @Composable
 private fun LoadingPlaceholder(modifier: Modifier = Modifier) {
-    PlaceholderBox(modifier)
+    SatsPlaceholderBox(modifier)
 }
 
 @Composable

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressBar.kt
@@ -29,7 +29,7 @@ fun SatsLinearProgressBar(
     Canvas(
         modifier
             .progressSemantics(progress)
-            .height(8.dp)
+            .height(4.dp)
             .focusable(),
     ) {
         // Remove extra padding added by the rounded line cap


### PR DESCRIPTION
**New Challenge Cards and updated Tags which are used within the cards 🎴** 

Cards: [Figma design](https://www.figma.com/file/F1I7j15pqrCOkB55ypUqtx/Activity?type=design&node-id=27660-26668&mode=design&t=C0JWiG5xI6k7ymvg-0)

Also updated the thickness of progress bars as per the design system 📏 

| dark mode | light mode |
| --- | --- |
| ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/08712aa2-988c-4de2-900d-26337c8b4cc5) | ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/222918fa-2c03-40fa-8574-f92e880e3580) |
| ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/4b444f01-cfed-4b49-9e7e-0f57a58b8171) | ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/6d03ae22-b554-454e-a36c-b1484446c5dc) |