### PR TITLE
NMA-6417: Fix border color of unselected chips

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
@@ -63,7 +63,7 @@ fun SatsFilterChip(
             true -> Color.Transparent
 
             false -> when (isEnabled) {
-                true -> SatsTheme.colors2.graphicalElements.chips.unselected.default.fg
+                true -> SatsTheme.colors2.graphicalElements.chips.unselected.default.bg
                 false -> SatsTheme.colors2.graphicalElements.chips.unselected.disabled.fg
             }
         },


### PR DESCRIPTION
| Before |   After  |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/e5e53551-fa8a-401a-9aac-3375c5bed5d0)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/5b4ce312-137c-4496-b00e-0f575b4b1b05)|
