### PR TITLE
NMA-6418: Put clean button previews behind fixed backgrounds

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -127,7 +127,13 @@ private fun buttonPadding(isLarge: Boolean): PaddingValues {
 @Composable
 private fun SatsButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        val backgroundColor = when (color) {
+            SatsButtonColor.Clean -> SatsTheme.colors2.backgrounds.fixed.primary.bg.default
+            SatsButtonColor.CleanSecondary -> SatsTheme.colors2.backgrounds.fixed.primary.bg.default
+            else -> SatsTheme.colors2.backgrounds.primary.bg.default
+        }
+
+        SatsSurface(color = backgroundColor, useMaterial3 = true) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 SatsButton(onClick = {}, color.name, Modifier.padding(SatsTheme.spacing.s), color)
                 SatsButton(


### PR DESCRIPTION
| Before |   After  |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/cdcf80b7-6c42-4124-812d-92354e40ec7d)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/fec17a4c-fc56-4724-bcaf-9a32475eea33)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/4cd7ded5-892c-499d-8b97-7cfe5a893b5b)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/8bd3b22e-9341-477d-9acf-7cde4a9368c1)|
![image](https://github.com/sats-group/sats-dna-android/assets/386122/8cd11f71-da29-47bc-b977-2e840619c046)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/def1e924-93bd-4df7-b5ce-12acbf8c0a8c)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/a0244277-7edb-4c47-a2db-c92a5405c7d6)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/6c657652-85a1-47df-a04e-5bbe6d4139a7)|