### PR TITLE
NMA-6452: Expose top app bar container color

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsLargeTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsLargeTopAppBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.button.SatsTopAppBarIconButton
@@ -46,16 +45,10 @@ fun SatsLargeTopAppBar(
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
 ) {
-    val scrolledContainerColor = if (SatsTheme.colors2.isLightMode) {
-        SatsTheme.colors2.surfaces.fixed.primary.bg.default.copy(alpha = .05f)
-    } else {
-        SatsTheme.colors2.surfaces.primary.bg.default
-    }.compositeOver(SatsTheme.colors2.backgrounds.primary.bg.default)
-
     LargeTopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = SatsTheme.colors2.backgrounds.primary.bg.default,
-            scrolledContainerColor = scrolledContainerColor,
+            scrolledContainerColor = SatsTopAppBarDefaults.containerColor,
         ),
         title = title,
         modifier = modifier,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsTopAppBar.kt
@@ -50,16 +50,10 @@ fun SatsTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior? = null,
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
 ) {
-    val scrolledContainerColor = if (SatsTheme.colors2.isLightMode) {
-        SatsTheme.colors2.surfaces.fixed.primary.bg.default.copy(alpha = .05f)
-    } else {
-        SatsTheme.colors2.surfaces.primary.bg.default
-    }.compositeOver(SatsTheme.colors2.backgrounds.primary.bg.default)
-
     // If we don't have a scroll behaviour, then we need to always separate the top app bar from the following
     // content, and using the same color as we would when the content was scrolled makes sense here.
     val containerColor = if (scrollBehavior == null) {
-        scrolledContainerColor
+        SatsTopAppBarDefaults.containerColor
     } else {
         SatsTheme.colors2.backgrounds.primary.bg.default
     }
@@ -67,7 +61,7 @@ fun SatsTopAppBar(
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = containerColor,
-            scrolledContainerColor = scrolledContainerColor,
+            scrolledContainerColor = SatsTopAppBarDefaults.containerColor,
         ),
         title = {
             ProvideTextStyle(
@@ -85,6 +79,15 @@ fun SatsTopAppBar(
         scrollBehavior = scrollBehavior,
         windowInsets = windowInsets,
     )
+}
+
+object SatsTopAppBarDefaults {
+    val containerColor
+        @Composable get() = if (SatsTheme.colors2.isLightMode) {
+            SatsTheme.colors2.surfaces.fixed.primary.bg.default.copy(alpha = .05f)
+        } else {
+            SatsTheme.colors2.surfaces.primary.bg.default
+        }.compositeOver(SatsTheme.colors2.backgrounds.primary.bg.default)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
This would allow us to go from

| this |  to this |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/67b12f22-fa0c-42e0-93db-ce4b84e08e85)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/857a08b7-e462-4e55-80ee-14bfe871b4cc)|

and

| this |  to this |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/1f9d23f5-3bf9-4fdf-9f4c-564b1e9384df)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/90c136eb-717f-4ecb-8552-ec1b846eec23)|
