### PR TITLE
NMA-6460: Create and use dismiss button in Disabled Challenge Card

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -34,6 +34,7 @@ import com.sats.dna.components.button.SatsBellIconButton
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.components.button.SatsButtonSize
+import com.sats.dna.components.button.SatsDismissButton
 import com.sats.dna.components.button.SatsIconButton
 import com.sats.dna.components.button.SatsInCardCardButton
 import com.sats.dna.components.button.SatsNavigationCardButton
@@ -137,6 +138,14 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                         )
                     }
                 }
+
+                SatsDismissButton(
+                    dismissLabel = "Dismiss",
+                    onDismissClicked = { },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = SatsTheme.spacing.m),
+                )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)) {
                     SatsBellIconButton(

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -142,9 +142,7 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                 SatsDismissButton(
                     dismissLabel = "Dismiss",
                     onDismissClicked = { },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = SatsTheme.spacing.m),
+                    size = controlPanelState.size,
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)) {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
@@ -69,8 +69,9 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
                     imageUrl = null,
                     title = "STREAK WEEK",
                     statusText = "Not completed",
+                    dismissLabel = "Dismiss",
                     onCardClick = {},
-                    onDeleteClick = {},
+                    onDismissClicked = {},
                 ),
                 modifier = Modifier
                     .height(255.dp)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -1,13 +1,10 @@
 package com.sats.dna.components.button
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -19,13 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -34,12 +25,9 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.lerp
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.theme.SatsTheme
@@ -126,79 +114,6 @@ fun SatsButton(
             Text(label, maxLines = 1, style = textStyle(size))
         }
     }
-}
-
-@Composable
-private fun buttonPadding(size: SatsButtonSize): PaddingValues {
-    val vertical = animateDpAsState(
-        when (size) {
-            SatsButtonSize.Small -> SatsTheme.spacing.xs
-            SatsButtonSize.Basic -> SatsTheme.spacing.xs
-            SatsButtonSize.Large -> SatsTheme.spacing.s
-        },
-        label = "Vertical padding",
-    )
-
-    val horizontal = animateDpAsState(
-        when (size) {
-            SatsButtonSize.Small -> SatsTheme.spacing.xs
-            SatsButtonSize.Basic -> SatsTheme.spacing.s
-            SatsButtonSize.Large -> SatsTheme.spacing.m
-        },
-        label = "Horizontal padding",
-    )
-
-    return PaddingValues(
-        horizontal = horizontal.value,
-        vertical = vertical.value,
-    )
-}
-
-@Composable
-private fun minContentHeight(size: SatsButtonSize): Dp {
-    return animateDpAsState(
-        when (size) {
-            SatsButtonSize.Small -> 16.dp
-            SatsButtonSize.Basic -> 24.dp
-            SatsButtonSize.Large -> 24.dp
-        },
-        label = "Content height",
-    ).value
-}
-
-@Composable
-private fun textStyle(size: SatsButtonSize): TextStyle {
-    return animateTextStyleAsState(
-        when (size) {
-            SatsButtonSize.Small -> SatsTheme.typography.normal.buttonSmall
-            SatsButtonSize.Basic -> SatsTheme.typography.normal.buttonBasic
-            SatsButtonSize.Large -> SatsTheme.typography.normal.buttonLarge
-        },
-    ).value
-}
-
-@Composable
-private fun animateTextStyleAsState(targetValue: TextStyle): State<TextStyle> {
-    val animation = remember { Animatable(0f) }
-
-    var previousTextStyle by remember { mutableStateOf(targetValue) }
-    var nextTextStyle by remember { mutableStateOf(targetValue) }
-
-    val textStyleState = remember(animation.value) {
-        derivedStateOf {
-            lerp(previousTextStyle, nextTextStyle, animation.value)
-        }
-    }
-
-    LaunchedEffect(targetValue) {
-        previousTextStyle = textStyleState.value
-        nextTextStyle = targetValue
-
-        animation.snapTo(0f)
-        animation.animateTo(1f, animationSpec = spring())
-    }
-
-    return textStyleState
 }
 
 @PreviewLightDark

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButtonAnimation.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButtonAnimation.kt
@@ -1,0 +1,92 @@
+package com.sats.dna.components.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.lerp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+internal fun buttonPadding(size: SatsButtonSize): PaddingValues {
+    val vertical = animateDpAsState(
+        when (size) {
+            SatsButtonSize.Small -> SatsTheme.spacing.xs
+            SatsButtonSize.Basic -> SatsTheme.spacing.xs
+            SatsButtonSize.Large -> SatsTheme.spacing.s
+        },
+        label = "Vertical padding",
+    )
+
+    val horizontal = animateDpAsState(
+        when (size) {
+            SatsButtonSize.Small -> SatsTheme.spacing.xs
+            SatsButtonSize.Basic -> SatsTheme.spacing.s
+            SatsButtonSize.Large -> SatsTheme.spacing.m
+        },
+        label = "Horizontal padding",
+    )
+
+    return PaddingValues(
+        horizontal = horizontal.value,
+        vertical = vertical.value,
+    )
+}
+
+@Composable
+internal fun minContentHeight(size: SatsButtonSize): Dp {
+    return animateDpAsState(
+        when (size) {
+            SatsButtonSize.Small -> 16.dp
+            SatsButtonSize.Basic -> 24.dp
+            SatsButtonSize.Large -> 24.dp
+        },
+        label = "Content height",
+    ).value
+}
+
+@Composable
+internal fun textStyle(size: SatsButtonSize): TextStyle {
+    return animateTextStyleAsState(
+        when (size) {
+            SatsButtonSize.Small -> SatsTheme.typography.normal.buttonSmall
+            SatsButtonSize.Basic -> SatsTheme.typography.normal.buttonBasic
+            SatsButtonSize.Large -> SatsTheme.typography.normal.buttonLarge
+        },
+    ).value
+}
+
+@Composable
+internal fun animateTextStyleAsState(targetValue: TextStyle): State<TextStyle> {
+    val animation = remember { Animatable(0f) }
+
+    var previousTextStyle by remember { mutableStateOf(targetValue) }
+    var nextTextStyle by remember { mutableStateOf(targetValue) }
+
+    val textStyleState = remember(animation.value) {
+        derivedStateOf {
+            lerp(previousTextStyle, nextTextStyle, animation.value)
+        }
+    }
+
+    LaunchedEffect(targetValue) {
+        previousTextStyle = textStyleState.value
+        nextTextStyle = targetValue
+
+        animation.snapTo(0f)
+        animation.animateTo(1f, animationSpec = spring())
+    }
+
+    return textStyleState
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsDismissButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsDismissButton.kt
@@ -1,0 +1,118 @@
+package com.sats.dna.components.button
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.sats.dna.components.SatsSurface
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun SatsDismissButton(
+    dismissLabel: String,
+    onDismissClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: SatsButtonSize = SatsButtonSize.Small,
+    color: SatsButtonColor = SatsButtonColor.Clean,
+) {
+    var isCloseClicked by remember {
+        mutableStateOf(false)
+    }
+
+    Surface(
+        onClick = {
+            if (isCloseClicked) {
+                onDismissClicked()
+            } else {
+                isCloseClicked = true
+            }
+        },
+        modifier = modifier
+            .semantics { role = Role.Button }
+            .heightIn(min = minContentHeight(size))
+            .wrapContentWidth(),
+        shape = SatsTheme.shapes.roundedCorners.small,
+        interactionSource = remember { MutableInteractionSource() },
+        color = color.animatedContainerColor(enabled = true),
+        contentColor = color.animatedContentColor(true),
+        border = color.animatedBorderColor(true)?.let { BorderStroke(1.dp, it) },
+    ) {
+        AnimatedContent(
+            isCloseClicked,
+            label = "Animated content",
+        ) { isCloseClicked ->
+            val content = when {
+                isCloseClicked -> SatsDismissButtonContent.Dismiss
+                else -> SatsDismissButtonContent.Close
+            }
+
+            val iconContentSize = animateDpAsState(
+                when (size) {
+                    SatsButtonSize.Small -> 16.dp
+                    SatsButtonSize.Basic -> 18.dp
+                    SatsButtonSize.Large -> 24.dp
+                },
+                label = "Icon content size",
+            ).value
+
+            when (content) {
+                is SatsDismissButtonContent.Close -> {
+                    Icon(
+                        painter = SatsTheme.icons.close,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(SatsTheme.spacing.xs)
+                            .size(iconContentSize),
+                    )
+                }
+
+                is SatsDismissButtonContent.Dismiss -> {
+                    Text(
+                        text = dismissLabel,
+                        style = textStyle(size),
+                        maxLines = 1,
+                        modifier = Modifier.padding(SatsTheme.spacing.xs),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsDismissButtonClosePreview() {
+    SatsTheme {
+        SatsSurface {
+            SatsDismissButton("Dismiss", {}, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsDismissButtonDismissPreview() {
+    SatsTheme {
+        SatsSurface {
+            SatsDismissButton("Dismiss", {}, Modifier.padding(SatsTheme.spacing.m))
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsDismissButtonContent.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsDismissButtonContent.kt
@@ -1,0 +1,6 @@
+package com.sats.dna.components.button
+
+internal sealed interface SatsDismissButtonContent {
+    data object Close : SatsDismissButtonContent
+    data object Dismiss : SatsDismissButtonContent
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/ChallengeCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -31,8 +30,8 @@ import com.sats.dna.components.SatsTagShape
 import com.sats.dna.components.button.SatsButton
 import com.sats.dna.components.button.SatsButtonColor
 import com.sats.dna.components.button.SatsButtonSize
+import com.sats.dna.components.button.SatsDismissButton
 import com.sats.dna.components.progressbar.SatsLinearProgressBar
-import com.sats.dna.internal.MaterialIcon
 import com.sats.dna.theme.SatsTheme
 
 @Composable
@@ -69,7 +68,8 @@ fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
                 title = state.title,
                 statusText = state.statusText,
                 onCardClick = state.onCardClick,
-                onDeleteClick = state.onDeleteClick,
+                onDismissClicked = state.onDismissClicked,
+                dismissLabel = state.dismissLabel,
                 modifier = modifier,
             )
         }
@@ -102,8 +102,9 @@ sealed interface ChallengeCardState {
         val imageUrl: String?,
         val title: String,
         val statusText: String,
+        val dismissLabel: String,
         val onCardClick: () -> Unit,
-        val onDeleteClick: () -> Unit,
+        val onDismissClicked: () -> Unit,
         val modifier: Modifier = Modifier,
     ) : ChallengeCardState
 }
@@ -266,8 +267,9 @@ private fun DisabledChallengeCard(
     imageUrl: String?,
     title: String,
     statusText: String,
+    dismissLabel: String,
     onCardClick: () -> Unit,
-    onDeleteClick: () -> Unit,
+    onDismissClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ChallengeCardLayout(
@@ -277,13 +279,11 @@ private fun DisabledChallengeCard(
         onCardClick = onCardClick,
         isEnabled = false,
         deleteButton = {
-            IconButton(onClick = onDeleteClick) {
-                MaterialIcon(
-                    painter = SatsTheme.icons.delete,
-                    contentDescription = null,
-                    tint = SatsTheme.colors2.graphicalElements.icons.fixed,
-                )
-            }
+            SatsDismissButton(
+                onDismissClicked = onDismissClicked,
+                dismissLabel = dismissLabel,
+                modifier = Modifier.padding(SatsTheme.spacing.xs),
+            )
         },
         bottomContent = {
             Text(
@@ -345,7 +345,7 @@ private fun JoinedChallengeCardPreview() {
         ChallengeCard(
             ChallengeCardState.Joined(
                 imageUrl = null,
-                title = "STREAK WEEK",
+                title = "STREAK WEEK STREAK WEEK STREAK WEEK",
                 tagText = "23 days left!",
                 progress = 0.14f,
                 statusText = "1 out of 7 workouts",
@@ -367,8 +367,9 @@ private fun DisabledChallengeCardPreview() {
                 imageUrl = null,
                 title = "STREAK WEEK",
                 statusText = "Not completed",
+                dismissLabel = "Dismiss",
                 onCardClick = {},
-                onDeleteClick = {},
+                onDismissClicked = {},
             ),
             modifier = Modifier
                 .height(255.dp)


### PR DESCRIPTION
**Created new SatsDismissButton to be used in the disabled version of the new Challenge Card, but also new shit 💩** 

Design: [Figma](https://www.figma.com/file/Nu1V7557V7KovgpZCNDObQ/%F0%9F%93%B1-sats-app-components-new?type=design&node-id=4129-14318&mode=design&t=qz2m3VQuS7An3vDP-4)

| close | dismiss |
| --- | --- |
| ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/5e5d1b71-7b45-49dd-9d9b-4f5a84927fea) | ![image](https://github.com/sats-group/sats-dna-android/assets/107850862/b2fbaabe-35c0-482a-b30c-435d962ca0e2) |