### PR TITLE
NMA-6439: Add slot for image in fancy top app bar

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.coil.compose)
     implementation(libs.google.material)
     implementation(libs.kotlin.reflect)
     implementation(platform(libs.androidx.compose.bom))

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FancyTopAppBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FancyTopAppBarSampleScreen.kt
@@ -1,16 +1,25 @@
 package com.sats.dna.sample.screens
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import coil.compose.AsyncImage
 import com.sats.dna.components.SatsFancyTopAppBar
 import com.sats.dna.components.SatsSurface
+import com.sats.dna.components.SatsTag
+import com.sats.dna.components.SatsTagColor
 import com.sats.dna.components.button.SatsTopAppBarIconButton
 import com.sats.dna.components.rememberSatsFancyTopAppBarNestedScrollConnection
 import com.sats.dna.components.screen.SatsScreen
@@ -33,7 +42,29 @@ fun FancyTopAppBarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) 
             val coroutineScope = rememberCoroutineScope()
 
             SatsFancyTopAppBar(
-                imageUrl = "https://picsum.photos/1920/1080",
+                image = { shade ->
+                    Box {
+                        AsyncImage(
+                            modifier = Modifier.fillMaxSize(),
+                            model = "https://picsum.photos/1920/1080",
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                        )
+
+                        shade()
+
+                        SatsTag(
+                            text = "New release",
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(SatsTheme.spacing.m)
+                                .graphicsLayer {
+                                    alpha = scrollConnection.expandPercent
+                                },
+                            color = SatsTagColor.Featured,
+                        )
+                    }
+                },
                 title = "GX Class That Has a Very Long Name",
                 scrollConnection = scrollConnection,
                 navigationIcon = {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
@@ -69,6 +69,25 @@ fun SatsFancyTopAppBar(
     actions: @Composable RowScope.() -> Unit = {},
     scrollConnection: SatsFancyTopAppBarNestedScrollConnection? = null,
 ) {
+    SatsFancyTopAppBar(
+        image = { HeaderImage(imageUrl, expandPercent = it) },
+        title = title,
+        modifier = modifier,
+        navigationIcon = navigationIcon,
+        actions = actions,
+        scrollConnection = scrollConnection,
+    )
+}
+
+@Composable
+fun SatsFancyTopAppBar(
+    image: @Composable (expandPercent: Float) -> Unit,
+    title: String,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    scrollConnection: SatsFancyTopAppBarNestedScrollConnection? = null,
+) {
     val expandPercent = if (scrollConnection != null) {
         (scrollConnection.currentHeightPx - scrollConnection.collapsedHeightPx) /
             (scrollConnection.expandedHeightPx - scrollConnection.collapsedHeightPx)
@@ -94,7 +113,7 @@ fun SatsFancyTopAppBar(
         Layout(
             modifier = modifier,
             contents = listOf(
-                { HeaderImage(imageUrl, expandPercent) },
+                { Header(expandPercent) { image(expandPercent) } },
                 { Box { navigationIcon() } },
                 { Row(content = actions) },
                 { ExpandedHeaderText(title, expandPercent, Modifier.padding(horizontal = SatsTheme.spacing.xxl)) },
@@ -290,7 +309,7 @@ private fun HeaderImage(
     expandPercent: Float,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier) {
+    Header(expandPercent, modifier) {
         if (LocalInspectionMode.current) {
             Image(
                 modifier = Modifier.fillMaxSize(),
@@ -306,6 +325,17 @@ private fun HeaderImage(
                 contentScale = ContentScale.Crop,
             )
         }
+    }
+}
+
+@Composable
+private fun Header(
+    expandPercent: Float,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier) {
+        content()
 
         HeaderImageShade(expandPercent, Modifier.fillMaxSize())
     }


### PR DESCRIPTION
**Builds upon https://github.com/sats-group/sats-dna-android/pull/389.**

Realized we might need to do this in order to support stuff like the Club Details image gallery and the New Release tags and stuff.

![image](https://github.com/sats-group/sats-dna-android/assets/386122/ebe775a5-ad6a-4139-99b7-c6fd86060ed4)
