### PR TITLE
NMA-6422: Remove SatsSurface from General List Item

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
@@ -57,7 +57,7 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
             SatsHorizontalDivider()
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
-                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
             ) {
                 listItems().forEach {
                     SatsCard {
@@ -71,7 +71,7 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
 
 @Preview
 @Composable
-private fun listItems(): List<@Composable () -> Unit>  {
+private fun listItems(): List<@Composable () -> Unit> {
     return listOf(
         {
             SatsGeneralListItem(
@@ -135,7 +135,7 @@ private fun listItems(): List<@Composable () -> Unit>  {
 
 @PreviewLightDark
 @Composable
-private fun SampleScreenPreview() {
+private fun GeneralListItemScreenPreview() {
     SatsTheme {
         GeneralListItemScreen(navigateUp = {})
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/GeneralListItemSampleScreen.kt
@@ -2,17 +2,24 @@ package com.sats.dna.sample.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.AdvancedTrailingContent
 import com.sats.dna.components.SatsGeneralListItem
 import com.sats.dna.components.SatsGeneralListItemDefaults
+import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.SimpleTrailingContent
+import com.sats.dna.components.card.SatsCard
 import com.sats.dna.theme.SatsTheme
 
 data object GeneralListItemSampleScreen : SampleScreen(
@@ -27,17 +34,54 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
         Column(
             Modifier
                 .padding(innerPadding)
-                .padding(SatsTheme.spacing.m)
+                .padding(top = SatsTheme.spacing.m)
                 .fillMaxSize()
-                .wrapContentSize(),
-            Arrangement.spacedBy(SatsTheme.spacing.m),
+                .verticalScroll(rememberScrollState()),
         ) {
+            Text(
+                modifier = Modifier.padding(horizontal = SatsTheme.spacing.m),
+                text = "In list",
+                style = SatsTheme.typography.medium.small,
+            )
+            listItems().forEach {
+                SatsHorizontalDivider()
+                it()
+            }
+            Spacer(Modifier.height(SatsTheme.spacing.m))
+
+            Text(
+                modifier = Modifier.padding(horizontal = SatsTheme.spacing.m),
+                text = "In cards",
+                style = SatsTheme.typography.medium.small,
+            )
+            SatsHorizontalDivider()
+            Column(
+                Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s)
+            ) {
+                listItems().forEach {
+                    SatsCard {
+                        it()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun listItems(): List<@Composable () -> Unit>  {
+    return listOf(
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
                 title = "General List Item",
                 icon = SatsTheme.icons.info,
             )
+        },
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -45,6 +89,8 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
                 subtitle = "Subtitle",
                 icon = SatsTheme.icons.info,
             )
+        },
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -52,6 +98,8 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
                 icon = SatsTheme.icons.info,
                 trailingContent = { SimpleTrailingContent() },
             )
+        },
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -59,6 +107,8 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
                 icon = SatsTheme.icons.info,
                 trailingContent = { AdvancedTrailingContent() },
             )
+        },
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -70,6 +120,8 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
                     iconColor = SatsTheme.colors2.buttons.action.default.fg,
                 ),
             )
+        },
+        {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -77,13 +129,13 @@ private fun GeneralListItemScreen(navigateUp: () -> Unit, modifier: Modifier = M
                 subtitle = "Subtitle",
                 trailingContent = { SimpleTrailingContent() },
             )
-        }
-    }
+        },
+    )
 }
 
 @PreviewLightDark
 @Composable
-private fun Preview() {
+private fun SampleScreenPreview() {
     SatsTheme {
         GeneralListItemScreen(navigateUp = {})
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
@@ -46,7 +46,7 @@ fun SatsCircularProgressIndicator(
 
 @PreviewLightDark
 @Composable
-private fun GeneralListItemPreview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
+private fun SatsCircularProgressIndicatorPreview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             SatsCircularProgressIndicator(progress, Modifier.padding(SatsTheme.spacing.m))

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
@@ -46,7 +46,7 @@ fun SatsCircularProgressIndicator(
 
 @PreviewLightDark
 @Composable
-private fun Preview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
+private fun GeneralListItemPreview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             SatsCircularProgressIndicator(progress, Modifier.padding(SatsTheme.spacing.m))

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
@@ -34,34 +34,32 @@ fun SatsGeneralListItem(
     colors: SatsGeneralListItemColors = SatsGeneralListItemDefaults.generalListItemColors(),
     isEnabled: Boolean = true,
 ) {
-    SatsSurface(modifier) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
-            modifier = Modifier
-                .clickable(onClick = onClick, enabled = isEnabled)
-                .padding(
-                    vertical = SatsTheme.spacing.s,
-                    horizontal = SatsTheme.spacing.m,
-                ),
-        ) {
-            icon?.let {
-                MaterialIcon(
-                    it,
-                    null,
-                    tint = colors.iconColor,
-                    modifier = Modifier.size(18.dp),
-                )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
+        modifier = modifier
+            .clickable(onClick = onClick, enabled = isEnabled)
+            .padding(
+                vertical = SatsTheme.spacing.s,
+                horizontal = SatsTheme.spacing.m,
+            ),
+    ) {
+        icon?.let {
+            MaterialIcon(
+                it,
+                null,
+                tint = colors.iconColor,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Column(Modifier.weight(1f)) {
+            MaterialText(title, color = colors.titleColor)
+            subtitle?.let {
+                MaterialText(it, color = colors.subtitleColor)
             }
-            Column(Modifier.weight(1f)) {
-                MaterialText(title, color = colors.titleColor)
-                subtitle?.let {
-                    MaterialText(it, color = colors.subtitleColor)
-                }
-            }
-            trailingContent?.let {
-                it()
-            }
+        }
+        trailingContent?.let {
+            it()
         }
     }
 }
@@ -124,7 +122,7 @@ private class DefaultSatsGeneralListItem(
 
 @PreviewLightDark
 @Composable
-private fun Preview() {
+private fun GeneralListItemPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             SatsGeneralListItem(
@@ -139,7 +137,7 @@ private fun Preview() {
 
 @PreviewLightDark
 @Composable
-private fun WithSubtitle() {
+private fun GeneralListItemWithSubtitlePreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
             SatsGeneralListItem(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
@@ -138,7 +138,7 @@ private fun DecorationBox(
 
 @PreviewLightDark
 @Composable
-private fun Preview() {
+private fun GeneralListItemPreview() {
     SatsTheme {
         var query by remember { mutableStateOf("") }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
@@ -138,7 +138,7 @@ private fun DecorationBox(
 
 @PreviewLightDark
 @Composable
-private fun GeneralListItemPreview() {
+private fun SatsSearchBarPreview() {
     SatsTheme {
         var query by remember { mutableStateOf("") }
 
@@ -154,7 +154,7 @@ private fun GeneralListItemPreview() {
 
 @PreviewLightDark
 @Composable
-private fun PreviewWithQuery() {
+private fun WithQueryPreview() {
     SatsTheme {
         var query by remember { mutableStateOf("SATS Carl Berner") }
 
@@ -170,7 +170,7 @@ private fun PreviewWithQuery() {
 
 @PreviewLightDark
 @Composable
-private fun PreviewWithBackButton() {
+private fun WithBackButtonPreview() {
     SatsTheme {
         var query by remember { mutableStateOf("") }
 


### PR DESCRIPTION
### What's new?
Ref [this discussion in Figma](https://www.figma.com/file/Nu1V7557V7KovgpZCNDObQ?node-id=1985:3873&mode=design#733684478) the general list items do not need to have a set surface background and should instead inherit their parents background color. 

I checked all places where this is already used, and in all usages the list items were already wrapped in a SatsCard so this shouldn't really break anything in the app. But please double check 🙈

<img src="https://github.com/sats-group/sats-dna-android/assets/48335680/0efecbba-fb35-401c-8c96-700850869316" width=40%/> 
<img src="https://github.com/sats-group/sats-dna-android/assets/48335680/1eec3da2-edda-4b51-9900-bfbd8ffb5267" width=40%/>

