### PR TITLE
NMA-6473: Reduce line heights for placeholder paragraph

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPlaceholders.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPlaceholders.kt
@@ -77,7 +77,7 @@ fun SatsPlaceholderParagraph(
         "Maecenas venenatis fermentum ullamcorper.",
     )
 
-    Column(modifier, spacedBy(SatsTheme.spacing.xs)) {
+    Column(modifier, spacedBy(SatsTheme.spacing.xxs)) {
         repeat(lines) { lineNumber ->
             val line = texts[lineNumber % texts.count()]
 


### PR DESCRIPTION
This is closer to our actual text line heights.

| Before |         After        |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/8fe5ff7f-f521-4237-84bf-0efe0fd7a156)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/ecbb0b0e-a31f-4f83-9cff-c6ddbaa23382)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/fab38f6b-66fa-4ab2-ae90-52ffbb3ad735)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/c2558cb5-c291-4f4a-a115-25b42eb55430)|
