### PR TITLE
NMA-6476: Set correct signal surface bg in dark mode

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
@@ -489,7 +489,7 @@ internal val SatsDarkColors2 = SatsColors2(
             ),
         ),
         featured = SatsColors2.SignalSurfaces.Featured(
-            bg = SatsColorPrimitives.BrightBlue160,
+            bg = SatsColorPrimitives.SatsCoral190,
             fg = SatsColors2.SignalSurfaces.Featured.Fg(
                 default = SatsColorPrimitives.White100,
                 alternate = SatsColorPrimitives.SatsCoral90,


### PR DESCRIPTION
This was wrong before. It's right now.