### PR TITLE
NMA-6479: Refactor colors to use color sets

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ButtonsSampleScreen.kt
@@ -76,7 +76,7 @@ private fun ButtonsScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                 SatsButtonColor.Action,
             ).forEach { color ->
                 val backgroundColor = if (color == SatsButtonColor.Clean || color == SatsButtonColor.CleanSecondary) {
-                    SatsTheme.colors2.backgrounds.fixed.primary.bg.default
+                    SatsTheme.colors2.backgrounds2.fixed.primary.default.bg
                 } else {
                     Color.Transparent
                 }
@@ -315,7 +315,7 @@ private fun ControlPanel(state: ControlPanelState) {
 @Composable
 private fun ButtonsScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             ButtonsScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeBackgroundSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeBackgroundSampleScreen.kt
@@ -57,7 +57,7 @@ private fun ChallengeBackgroundScreen(navigateUp: () -> Unit, modifier: Modifier
                     Text(
                         text = "Challenge Background",
                         style = SatsTheme.typography.normal.headline3,
-                        color = SatsTheme.colors2.backgrounds.fixed.primary.fg.default,
+                        color = SatsTheme.colors2.backgrounds2.fixed.primary.default.fg,
                     )
                 },
                 navigationIcon = { SatsTopAppBarIconButton(navigateUp, SatsTheme.icons.back, onClickLabel = null) },
@@ -74,7 +74,7 @@ private fun ChallengeBackgroundScreen(navigateUp: () -> Unit, modifier: Modifier
 @Composable
 private fun ChallengeBackgroundScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             ChallengeBackgroundScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CheckboxSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/CheckboxSampleScreen.kt
@@ -60,9 +60,9 @@ private fun CheckboxScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
 @Composable
 private fun Section(label: String, isFixedBackground: Boolean = false, content: @Composable () -> Unit) {
     val color = if (isFixedBackground) {
-        SatsTheme.colors2.backgrounds.fixed.primary.bg.default
+        SatsTheme.colors2.backgrounds2.fixed.primary.default.bg
     } else {
-        SatsTheme.colors2.surfaces.primary.bg.default
+        SatsTheme.colors2.surfaces2.primary.default.bg
     }
 
     SatsSurface(Modifier.fillMaxWidth(), color = color, shape = SatsTheme.shapes.roundedCorners.medium) {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/Colors2SampleScreen.kt
@@ -245,30 +245,30 @@ private fun GraphicalElements() {
         }
 
         Section("Progress Bar", SectionLevel.Level2, base = "graphicalElements.progressBar") {
-            val base = SatsTheme.colors2.graphicalElements.progressBar
+            val base = SatsTheme.colors2.graphicalElements.progressBar2
 
             ColorSample(
-                backgroundColor = base.bg named "base.bg",
-                contentColor = base.indicator named "base.indicator",
+                backgroundColor = base.default.bg named "base.default.bg",
+                contentColor = base.default.fg named "base.default.fg",
             )
 
             ColorSample(
-                backgroundColor = base.bg named "base.bg",
-                contentColor = base.indicatorAlternate named "base.indicatorAlternate",
+                backgroundColor = base.default.bg named "base.default.bg",
+                contentColor = base.alternate.fg named "base.alternate.fg",
             )
         }
 
         Section("Fixed Progress Bar", SectionLevel.Level2, base = "graphicalElements.fixedProgressBar") {
-            val base = SatsTheme.colors2.graphicalElements.fixedProgressBar
+            val base = SatsTheme.colors2.graphicalElements.fixedProgressBar2
 
             ColorSample(
-                backgroundColor = base.bg named "base.bg",
-                contentColor = base.indicator named "base.indicator",
+                backgroundColor = base.default.bg named "base.default.bg",
+                contentColor = base.default.fg named "base.default.fg",
             )
 
             ColorSample(
-                backgroundColor = base.bg named "base.bg",
-                contentColor = base.indicatorAlternate named "base.indicatorAlternate",
+                backgroundColor = base.default.bg named "base.default.bg",
+                contentColor = base.alternate.fg named "base.alternate.fg",
             )
         }
 
@@ -610,46 +610,46 @@ private fun GraphicalElements() {
 @Composable
 private fun Backgrounds() {
     Section("Backgrounds", SectionLevel.Level1, base = "backgrounds") {
-        val base = SatsTheme.colors2.backgrounds
+        val base = SatsTheme.colors2.backgrounds2
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.alternate named "base.primary.fg.alternate",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgAlternate named "base.primary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.disabled named "base.primary.fg.disabled",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgDisabled named "base.primary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.selected named "base.primary.bg.selected",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.selected.bg named "base.primary.selected.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.alternate named "base.secondary.fg.alternate",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgAlternate named "base.secondary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.disabled named "base.secondary.fg.disabled",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgDisabled named "base.secondary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.selected named "base.secondary.bg.selected",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.selected.bg named "base.secondary.selected.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
     }
 }
@@ -657,26 +657,26 @@ private fun Backgrounds() {
 @Composable
 private fun FixedBackgrounds() {
     Section("Fixed Backgrounds", SectionLevel.Level1, base = "backgrounds.fixed") {
-        val base = SatsTheme.colors2.backgrounds.fixed
+        val base = SatsTheme.colors2.backgrounds2.fixed
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.alternate named "base.primary.fg.alternate",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgAlternate named "base.primary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.alternate named "base.secondary.fg.alternate",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgAlternate named "base.secondary.default.fgAlternate",
         )
     }
 }
@@ -684,126 +684,126 @@ private fun FixedBackgrounds() {
 @Composable
 private fun Surfaces() {
     Section("Surfaces", SectionLevel.Level1, base = "surfaces") {
-        val base = SatsTheme.colors2.surfaces
+        val base = SatsTheme.colors2.surfaces2
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.alternate named "base.primary.fg.alternate",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgAlternate named "base.primary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.disabled named "base.primary.fg.disabled",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgDisabled named "base.primary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.disabled named "base.primary.fg.disabled",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgDisabled named "base.primary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.success named "base.primary.fg.success",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgSuccess named "base.primary.default.fgSuccess",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.warning named "base.primary.fg.warning",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgWarning named "base.primary.default.fgWarning",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.error named "base.primary.fg.error",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgError named "base.primary.default.fgError",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.waitlist named "base.primary.fg.waitlist",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgWaitingList named "base.primary.default.fgWaitingList",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.neutral named "base.primary.fg.neutral",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgNeutral named "base.primary.default.fgNeutral",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.information named "base.primary.fg.information",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgInformation named "base.primary.default.fgInformation",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.featured named "base.primary.fg.featured",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgFeatured named "base.primary.default.fgFeatured",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.selected named "base.primary.bg.selected",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.selected.bg named "base.primary.selected.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.alternate named "base.secondary.fg.alternate",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgAlternate named "base.secondary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.disabled named "base.secondary.fg.disabled",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgDisabled named "base.secondary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.disabled named "base.secondary.fg.disabled",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgDisabled named "base.secondary.default.fgDisabled",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.success named "base.secondary.fg.success",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgSuccess named "base.secondary.default.fgSuccess",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.warning named "base.secondary.fg.warning",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgWarning named "base.secondary.default.fgWarning",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.error named "base.secondary.fg.error",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgError named "base.secondary.default.fgError",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.waitlist named "base.secondary.fg.waitlist",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgWaitingList named "base.secondary.default.fgWaitingList",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.neutral named "base.secondary.fg.neutral",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgNeutral named "base.secondary.default.fgNeutral",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.information named "base.secondary.fg.information",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgInformation named "base.secondary.default.fgInformation",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.featured named "base.secondary.fg.featured",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgFeatured named "base.secondary.default.fgFeatured",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.selected named "base.secondary.bg.selected",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.selected.bg named "base.secondary.selected.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
     }
 }
@@ -811,26 +811,26 @@ private fun Surfaces() {
 @Composable
 private fun FixedSurfaces() {
     Section("Fixed Surfaces", SectionLevel.Level1, base = "surfaces.fixed") {
-        val base = SatsTheme.colors2.surfaces.fixed
+        val base = SatsTheme.colors2.surfaces2.fixed
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.default named "base.primary.fg.default",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fg named "base.primary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.primary.bg.default named "base.primary.bg.default",
-            contentColor = base.primary.fg.alternate named "base.primary.fg.alternate",
+            backgroundColor = base.primary.default.bg named "base.primary.default.bg",
+            contentColor = base.primary.default.fgAlternate named "base.primary.default.fgAlternate",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.default named "base.secondary.fg.default",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fg named "base.secondary.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.secondary.bg.default named "base.secondary.bg.default",
-            contentColor = base.secondary.fg.alternate named "base.secondary.fg.alternate",
+            backgroundColor = base.secondary.default.bg named "base.secondary.default.bg",
+            contentColor = base.secondary.default.fgAlternate named "base.secondary.default.fgAlternate",
         )
     }
 }
@@ -838,61 +838,61 @@ private fun FixedSurfaces() {
 @Composable
 private fun SignalSurfaces() {
     Section("Signal Surface", SectionLevel.Level1, base = "signalSurfaces") {
-        val base = SatsTheme.colors2.signalSurfaces
+        val base = SatsTheme.colors2.signalSurfaces2
 
         ColorSample(
-            backgroundColor = base.success.bg named "base.success.bg",
-            contentColor = base.success.fg.default named "base.success.fg.default",
+            backgroundColor = base.success.default.bg named "base.success.default.bg",
+            contentColor = base.success.default.fg named "base.success.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.warning.bg named "base.warning.bg",
-            contentColor = base.warning.fg.default named "base.warning.fg.default",
+            backgroundColor = base.warning.default.bg named "base.warning.default.bg",
+            contentColor = base.warning.default.fg named "base.warning.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.warning.bg named "base.warning.bg",
-            contentColor = base.warning.fg.alternate named "base.warning.fg.alternate",
+            backgroundColor = base.warning.default.bg named "base.warning.default.bg",
+            contentColor = base.warning.alternate.fg named "base.warning.alternate.fg",
         )
 
         ColorSample(
-            backgroundColor = base.error.bg named "base.error.bg",
-            contentColor = base.error.fg.default named "base.error.fg.default",
+            backgroundColor = base.error.default.bg named "base.error.default.bg",
+            contentColor = base.error.default.fg named "base.error.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.error.bg named "base.error.bg",
-            contentColor = base.error.fg.alternate named "base.error.fg.alternate",
+            backgroundColor = base.error.default.bg named "base.error.default.bg",
+            contentColor = base.error.alternate.fg named "base.error.alternate.fg",
         )
 
         ColorSample(
-            backgroundColor = base.waitingList.bg named "base.waitingList.bg",
-            contentColor = base.waitingList.fg.default named "base.waitingList.fg.default",
+            backgroundColor = base.waitingList.default.bg named "base.waitingList.default.bg",
+            contentColor = base.waitingList.default.fg named "base.waitingList.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.waitingList.bg named "base.waitingList.bg",
-            contentColor = base.waitingList.fg.alternate named "base.waitingList.fg.alternate",
+            backgroundColor = base.waitingList.default.bg named "base.waitingList.default.bg",
+            contentColor = base.waitingList.alternate.fg named "base.waitingList.alternate.fg",
         )
 
         ColorSample(
-            backgroundColor = base.neutral.bg named "base.neutral.bg",
-            contentColor = base.neutral.fg.default named "base.neutral.fg.default",
+            backgroundColor = base.neutral.default.bg named "base.neutral.default.bg",
+            contentColor = base.neutral.default.fg named "base.neutral.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.neutral.bg named "base.neutral.bg",
-            contentColor = base.neutral.fg.alternate named "base.neutral.fg.alternate",
+            backgroundColor = base.neutral.default.bg named "base.neutral.default.bg",
+            contentColor = base.neutral.alternate.fg named "base.neutral.alternate.fg",
         )
 
         ColorSample(
-            backgroundColor = base.information.bg named "base.information.bg",
-            contentColor = base.information.fg.default named "base.information.fg.default",
+            backgroundColor = base.information.default.bg named "base.information.default.bg",
+            contentColor = base.information.default.fg named "base.information.default.fg",
         )
 
         ColorSample(
-            backgroundColor = base.information.bg named "base.information.bg",
-            contentColor = base.information.fg.alternate named "base.information.fg.alternate",
+            backgroundColor = base.information.default.bg named "base.information.default.bg",
+            contentColor = base.information.alternate.fg named "base.information.alternate.fg",
         )
     }
 }
@@ -977,7 +977,7 @@ private fun ColorNameAndHex(backgroundColor: NamedColor, modifier: Modifier = Mo
 
         Text(
             backgroundColor.toHexString(),
-            color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+            color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
         )
     }
 }
@@ -997,7 +997,7 @@ class NamedColor(val name: String, val color: Color) {
 @Composable
 private fun ColorSamplePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             ColorSample(
                 backgroundColor = Color.Green named "Color.Green",
                 contentColor = Color.Red named "Color.Red",

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/DividersSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/DividersSampleScreen.kt
@@ -78,7 +78,7 @@ private fun Section(label: String, modifier: Modifier = Modifier, content: @Comp
 @Composable
 private fun DividersScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             DividersScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FancyTopAppBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FancyTopAppBarSampleScreen.kt
@@ -105,7 +105,7 @@ fun FancyTopAppBarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) 
 @Composable
 private fun FancyTopAppBarScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             FancyTopAppBarScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FriendsBookingStatusSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/FriendsBookingStatusSampleScreen.kt
@@ -34,7 +34,7 @@ private fun FriendsBookingStatusScreen(navigateUp: () -> Unit, modifier: Modifie
                 .padding(innerPadding)
                 .fillMaxSize()
                 .wrapContentSize()
-                .background(SatsTheme.colors2.surfaces.primary.bg.default),
+                .background(SatsTheme.colors2.surfaces2.primary.default.bg),
         ) {
             friendsBookingStates.forEach { bookingState ->
                 SatsFriendsBookingStatusListItem(

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/JoinYourFriendsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/JoinYourFriendsSampleScreen.kt
@@ -36,7 +36,10 @@ private fun JoinYourFriendsSampleScreen(navigateUp: () -> Unit, modifier: Modifi
 @Composable
 private fun JoinYourFriendsSampleScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             JoinYourFriendsSampleScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SampleScreen.kt
@@ -40,7 +40,7 @@ sealed class SampleScreen(
     fun HomeListItem(navController: NavController) {
         ListItem(
             headlineContent = { Text(name) },
-            colors = ListItemDefaults.colors(containerColor = SatsTheme.colors2.backgrounds.primary.bg.default),
+            colors = ListItemDefaults.colors(containerColor = SatsTheme.colors2.backgrounds2.primary.default.bg),
             modifier = Modifier.clickable { navigate(navController) },
         )
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScaleBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ScaleBarSampleScreen.kt
@@ -44,7 +44,10 @@ private fun ScaleBarScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier
 @Composable
 private fun ScaleBarScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             ScaleBarScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SearchBarSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/SearchBarSampleScreen.kt
@@ -68,7 +68,10 @@ private fun SearchBarSampleScreen(navigateUp: () -> Unit, modifier: Modifier = M
 @Composable
 private fun SearchBarSampleScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SearchBarSampleScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TitledSectionSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/TitledSectionSampleScreen.kt
@@ -112,7 +112,7 @@ fun TitledSectionScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
 @Composable
 private fun TitledSectionScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             TitledSectionScreen(navigateUp = {})
         }
     }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/YourMostBookedSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/YourMostBookedSampleScreen.kt
@@ -33,7 +33,10 @@ private fun YourMostBookedSampleScreen(navigateUp: () -> Unit, modifier: Modifie
 @Composable
 private fun YourMostBookedSampleScreenPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             YourMostBookedSampleScreen(navigateUp = {})
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors2.kt
@@ -5,11 +5,20 @@ import androidx.compose.ui.graphics.Color
 class SatsColors2(
     val buttons: Buttons,
     val graphicalElements: GraphicalElements,
-    val backgrounds: Backgrounds,
-    val surfaces: Surfaces,
-    val signalSurfaces: SignalSurfaces,
+    val backgrounds2: Backgrounds2,
+    val surfaces2: Surfaces2,
+    val signalSurfaces2: SignalSurfaces2,
     val isLightMode: Boolean,
 ) {
+    @Deprecated("Use backgrounds2")
+    val backgrounds = Backgrounds(backgrounds2)
+
+    @Deprecated("Use backgrounds2")
+    val surfaces = Surfaces(surfaces2)
+
+    @Deprecated("Use signalSurfaces2")
+    val signalSurfaces = SignalSurfaces(signalSurfaces2)
+
     class Buttons(
         val primary: Primary,
         val secondary: Secondary,
@@ -21,159 +30,53 @@ class SatsColors2(
         val destructive: Destructive,
     ) {
         class Primary(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Disabled(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val default: ColorSet,
+            val disabled: ColorSet,
+        )
 
         class Secondary(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val outline: Color,
-                val fg: Color,
-            ) {
-                val bg: Color = Color.Transparent
-            }
-
-            class Disabled(
-                val outline: Color,
-                val fg: Color,
-            ) {
-                val bg: Color = Color.Transparent
-            }
-        }
+            val default: OutlinedColorSet,
+            val disabled: OutlinedColorSet,
+        )
 
         class Clean(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Disabled(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val default: ColorSet,
+            val disabled: ColorSet,
+        )
 
         class CleanSecondary(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val bg: Color,
-                val outline: Color,
-                val fg: Color,
-            )
-
-            class Disabled(
-                val bg: Color,
-                val outline: Color,
-                val fg: Color,
-            )
-        }
+            val default: OutlinedColorSet,
+            val disabled: OutlinedColorSet,
+        )
 
         class Action(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val fg: Color,
-            ) {
-                val bg = Color.Transparent
-            }
-
-            class Disabled(
-                val fg: Color,
-            ) {
-                val bg = Color.Transparent
-            }
-        }
+            val default: ColorSet,
+            val disabled: ColorSet,
+        )
 
         class WaitingListFilled(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Disabled(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val default: ColorSet,
+            val disabled: ColorSet,
+        )
 
         class WaitingListSecondary(
-            val default: Default,
-            val disabled: Disabled,
-        ) {
-            class Default(
-                val outline: Color,
-                val fg: Color,
-            ) {
-                val bg = Color.Transparent
-            }
-
-            class Disabled(
-                val outline: Color,
-                val fg: Color,
-            ) {
-                val bg = Color.Transparent
-            }
-        }
+            val default: OutlinedColorSet,
+            val disabled: OutlinedColorSet,
+        )
 
         class Destructive(
             val default: Default,
             val alternate: Alternate,
         ) {
             class Default(
-                val default: Default,
-                val disabled: Disabled,
-            ) {
-                class Default(
-                    val bg: Color,
-                    val fg: Color,
-                )
-
-                class Disabled(
-                    val bg: Color,
-                    val fg: Color,
-                )
-            }
+                val default: ColorSet,
+                val disabled: ColorSet,
+            )
 
             class Alternate(
-                val default: Default,
-                val disabled: Disabled,
-            ) {
-                class Default(
-                    val fg: Color,
-                ) {
-                    val outline: Color = fg
-                    val bg: Color = Color.Transparent
-                }
-
-                class Disabled(
-                    val fg: Color,
-                ) {
-                    val bg: Color = Color.Transparent
-                    val outline: Color = fg
-                }
-            }
+                val default: OutlinedColorSet,
+                val disabled: OutlinedColorSet,
+            )
         }
     }
 
@@ -183,8 +86,8 @@ class SatsColors2(
         val signalBorder: SignalBorder,
         val skeleton: Color,
         val navBar: NavBar,
-        val progressBar: ProgressBar,
-        val fixedProgressBar: FixedProgressBar,
+        val progressBar2: ProgressBar2,
+        val fixedProgressBar2: FixedProgressBar2,
         val graphs: Graphs,
         val selector: Selector,
         val selectorFixed: SelectorFixed,
@@ -199,6 +102,12 @@ class SatsColors2(
         val rewards: Rewards,
         val workouts: Workouts,
     ) {
+        @Deprecated("Replace with progressBar2")
+        val progressBar = ProgressBar(progressBar2)
+
+        @Deprecated("Replace with fixedProgressBar2")
+        val fixedProgressBar = FixedProgressBar(fixedProgressBar2)
+
         class Divider(
             val default: Color,
             val alternate: Color,
@@ -224,16 +133,36 @@ class SatsColors2(
             val notSelected: Color,
         )
 
-        class ProgressBar(
-            val indicator: Color,
-            val indicatorAlternate: Color,
-            val bg: Color,
+        class ProgressBar(progressBar2: ProgressBar2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.progressBar2.default.fg"))
+            val indicator: Color = progressBar2.default.fg
+
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.progressBar2.alternate.fg"))
+            val indicatorAlternate: Color = progressBar2.alternate.fg
+
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.progressBar2.default.bg"))
+            val bg: Color = progressBar2.default.bg
+        }
+
+        class ProgressBar2(
+            val default: ColorSet,
+            val alternate: ColorSet,
         )
 
-        class FixedProgressBar(
-            val indicator: Color,
-            val indicatorAlternate: Color,
-            val bg: Color,
+        class FixedProgressBar(fixedProgressBar2: FixedProgressBar2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.fixedProgressBar2.default.fg"))
+            val indicator: Color = fixedProgressBar2.default.fg
+
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.fixedProgressBar2.alternate.fg"))
+            val indicatorAlternate: Color = fixedProgressBar2.alternate.fg
+
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.graphicalElements.fixedProgressBar2.default.bg"))
+            val bg: Color = fixedProgressBar2.default.bg
+        }
+
+        class FixedProgressBar2(
+            val default: ColorSet,
+            val alternate: ColorSet,
         )
 
         class Graphs(
@@ -299,39 +228,14 @@ class SatsColors2(
             val selected: Selected,
         ) {
             class Unselected(
-                val default: Default,
-                val disabled: Disabled,
-            ) {
-                class Default(
-                    val bg: Color,
-                    val fg: Color,
-                )
-
-                class Disabled(
-                    val bg: Color,
-                    val fg: Color,
-                )
-            }
+                val default: ColorSet,
+                val disabled: ColorSet,
+            )
 
             class Selected(
-                val default: Default,
-                val disabled: Disabled,
-            ) {
-                class Default(
-                    val bg: Color,
-                    val fg: Color,
-                )
-
-                class Hover(
-                    val bg: Color,
-                    val fg: Color,
-                )
-
-                class Disabled(
-                    val bg: Color,
-                    val fg: Color,
-                )
-            }
+                val default: ColorSet,
+                val disabled: ColorSet,
+            )
         }
 
         class Toggle(
@@ -397,315 +301,520 @@ class SatsColors2(
         )
 
         class Tags(
-            val primary: Primary,
-            val secondary: Secondary,
-            val featured: Featured,
-        ) {
-            class Primary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Secondary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Featured(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val primary: ColorSet,
+            val secondary: ColorSet,
+            val featured: ColorSet,
+        )
 
         class Badge(
-            val primary: Primary,
-            val secondary: Secondary,
-            val tertiary: Tertiary,
-        ) {
-            class Primary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Secondary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Tertiary(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val primary: ColorSet,
+            val secondary: ColorSet,
+            val tertiary: ColorSet,
+        )
 
         class FixedBadge(
-            val primary: Primary,
-            val secondary: Secondary,
-            val tertiary: Tertiary,
-        ) {
-            class Primary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Secondary(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Tertiary(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val primary: ColorSet,
+            val secondary: ColorSet,
+            val tertiary: ColorSet,
+        )
 
         class Rewards(
-            val blue: Blue,
-            val silver: Silver,
-            val gold: Gold,
-            val platinum: Platinum,
-        ) {
-            class Blue(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Silver(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Gold(
-                val bg: Color,
-                val fg: Color,
-            )
-
-            class Platinum(
-                val bg: Color,
-                val fg: Color,
-            )
-        }
+            val blue: ColorSet,
+            val silver: ColorSet,
+            val gold: ColorSet,
+            val platinum: ColorSet,
+        )
 
         class Workouts(
-            val pt: Pt,
-            val gx: Gx,
-            val treatments: Treatments,
-            val gymfloor: Gymfloor,
-            val other: Other,
-            val bootcamp: Bootcamp,
-        ) {
-            class Pt(
-                val bg: Color,
-                val fg: Color,
-            )
+            val pt: ColorSet,
+            val gx: ColorSet,
+            val treatments: ColorSet,
+            val gymfloor: ColorSet,
+            val other: ColorSet,
+            val bootcamp: ColorSet,
+        )
+    }
 
-            class Gx(
-                val bg: Color,
-                val fg: Color,
-            )
+    class Backgrounds(backgrounds2: Backgrounds2) {
+        val primary = Primary(backgrounds2)
+        val secondary = Secondary(backgrounds2)
+        val fixed = Fixed(backgrounds2)
 
-            class Treatments(
-                val bg: Color,
-                val fg: Color,
-            )
+        class Primary(backgrounds2: Backgrounds2) {
+            val bg = Bg(backgrounds2)
+            val fg = Fg(backgrounds2)
 
-            class Gymfloor(
-                val bg: Color,
-                val fg: Color,
-            )
+            class Bg(backgrounds2: Backgrounds2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.primary.default.bg"))
+                val default: Color = backgrounds2.primary.default.bg
 
-            class Other(
-                val bg: Color,
-                val fg: Color,
-            )
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.primary.selected.bg"))
+                val selected: Color = backgrounds2.primary.selected.bg
+            }
 
-            class Bootcamp(
-                val bg: Color,
-                val fg: Color,
-            )
+            class Fg(backgrounds2: Backgrounds2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.primary.default.fg"))
+                val default: Color = backgrounds2.primary.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.primary.default.fgAlternate"))
+                val alternate: Color = backgrounds2.primary.default.fgAlternate
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.primary.default.fgDisabled"))
+                val disabled: Color = backgrounds2.primary.default.fgDisabled
+            }
+        }
+
+        class Secondary(backgrounds2: Backgrounds2) {
+            val bg = Bg(backgrounds2)
+            val fg = Fg(backgrounds2)
+
+            class Bg(backgrounds2: Backgrounds2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.secondary.default.bg"))
+                val default: Color = backgrounds2.secondary.default.bg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.secondary.selected.bg"))
+                val selected: Color = backgrounds2.secondary.selected.bg
+            }
+
+            class Fg(backgrounds2: Backgrounds2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.secondary.default.fg"))
+                val default: Color = backgrounds2.secondary.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.secondary.default.fgAlternate"))
+                val alternate: Color = backgrounds2.secondary.default.fgAlternate
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.secondary.default.fgDisabled"))
+                val disabled: Color = backgrounds2.secondary.default.fgDisabled
+            }
+        }
+
+        class Fixed(backgrounds2: Backgrounds2) {
+            val primary = Primary(backgrounds2)
+            val secondary = Secondary(backgrounds2)
+
+            class Primary(backgrounds2: Backgrounds2) {
+                val bg = Bg(backgrounds2)
+                val fg = Fg(backgrounds2)
+
+                class Bg(backgrounds2: Backgrounds2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.primary.default.bg"))
+                    val default: Color = backgrounds2.fixed.primary.default.bg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.primary.selected.bg"))
+                    val selected: Color = backgrounds2.fixed.primary.selected.bg
+                }
+
+                class Fg(backgrounds2: Backgrounds2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.primary.default.fg"))
+                    val default: Color = backgrounds2.fixed.primary.default.fg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.primary.default.fgAlternate"))
+                    val alternate: Color = backgrounds2.fixed.primary.default.fgAlternate
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.primary.default.fgDisabled"))
+                    val disabled: Color = backgrounds2.fixed.primary.default.fgDisabled
+                }
+            }
+
+            class Secondary(backgrounds2: Backgrounds2) {
+                val bg = Bg(backgrounds2)
+                val fg = Fg(backgrounds2)
+
+                class Bg(backgrounds2: Backgrounds2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.secondary.default.bg"))
+                    val default: Color = backgrounds2.fixed.secondary.default.bg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.secondary.selected.bg"))
+                    val selected: Color = backgrounds2.fixed.secondary.selected.bg
+                }
+
+                class Fg(backgrounds2: Backgrounds2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.secondary.default.fg"))
+                    val default: Color = backgrounds2.fixed.secondary.default.fg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.secondary.default.fgAlternate"))
+                    val alternate: Color = backgrounds2.fixed.secondary.default.fgAlternate
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.backgrounds2.fixed.secondary.default.fgDisabled"))
+                    val disabled: Color = backgrounds2.fixed.secondary.default.fgDisabled
+                }
+            }
         }
     }
 
-    class Backgrounds(
+    class Backgrounds2(
         val primary: Primary,
         val secondary: Secondary,
         val fixed: Fixed,
     ) {
         class Primary(
-            val bg: Bg,
-            val fg: Fg,
-        ) {
-            class Bg(
-                val default: Color,
-                val selected: Color,
-            )
-
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-                val disabled: Color,
-            )
-        }
+            val default: BackgroundColorSet,
+            val selected: BackgroundColorSet,
+        )
 
         class Secondary(
-            val bg: Bg,
-            val fg: Fg,
-        ) {
-            class Bg(
-                val default: Color,
-                val selected: Color,
-            )
-
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-                val disabled: Color,
-            )
-        }
+            val default: BackgroundColorSet,
+            val selected: BackgroundColorSet,
+        )
 
         class Fixed(
             val primary: Primary,
             val secondary: Secondary,
         ) {
             class Primary(
-                val bg: Bg,
-                val fg: Fg,
-            ) {
-                class Bg(
-                    val default: Color,
-                    val selected: Color,
-                )
-
-                class Fg(
-                    val default: Color,
-                    val alternate: Color,
-                    val disabled: Color,
-                )
-            }
+                val default: BackgroundColorSet,
+                val selected: BackgroundColorSet,
+            )
 
             class Secondary(
-                val bg: Bg,
-                val fg: Fg,
-            ) {
-                class Bg(
-                    val default: Color,
-                    val selected: Color,
-                )
+                val default: BackgroundColorSet,
+                val selected: BackgroundColorSet,
+            )
+        }
+    }
 
-                class Fg(
-                    val default: Color,
-                    val alternate: Color,
-                    val disabled: Color,
-                )
+    class Surfaces(surfaces2: Surfaces2) {
+        val primary = Primary(surfaces2)
+        val secondary = Secondary(surfaces2)
+        val fixed = Fixed(surfaces2)
+
+        class Primary(surfaces2: Surfaces2) {
+            val bg = Bg(surfaces2)
+            val fg = Fg(surfaces2)
+
+            class Bg(surfaces2: Surfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.bg"))
+                val default: Color = surfaces2.primary.default.bg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.selected.bg"))
+                val selected: Color = surfaces2.primary.selected.bg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.disabled.bg"))
+                val disabled: Color = surfaces2.primary.disabled.bg
+            }
+
+            class Fg(surfaces2: Surfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fg"))
+                val default: Color = surfaces2.primary.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgAlternate"))
+                val alternate: Color = surfaces2.primary.default.fgAlternate
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgDisabled"))
+                val disabled: Color = surfaces2.primary.default.fgDisabled
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgSuccess"))
+                val success: Color = surfaces2.primary.default.fgSuccess
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgWarning"))
+                val warning: Color = surfaces2.primary.default.fgWarning
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgError"))
+                val error: Color = surfaces2.primary.default.fgError
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgWaitingList"))
+                val waitlist: Color = surfaces2.primary.default.fgWaitingList
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgNeutral"))
+                val neutral: Color = surfaces2.primary.default.fgNeutral
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgInformation"))
+                val information: Color = surfaces2.primary.default.fgInformation
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.primary.default.fgFeatured"))
+                val featured: Color = surfaces2.primary.default.fgFeatured
+            }
+        }
+
+        class Secondary(surfaces2: Surfaces2) {
+            val bg = Bg(surfaces2)
+            val fg = Fg(surfaces2)
+
+            class Bg(surfaces2: Surfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.bg"))
+                val default: Color = surfaces2.secondary.default.bg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.selected.bg"))
+                val selected: Color = surfaces2.secondary.selected.bg
+            }
+
+            class Fg(surfaces2: Surfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fg"))
+                val default: Color = surfaces2.secondary.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgAlternate"))
+                val alternate: Color = surfaces2.secondary.default.fgAlternate
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgDisabled"))
+                val disabled: Color = surfaces2.secondary.default.fgDisabled
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgSuccess"))
+                val success: Color = surfaces2.secondary.default.fgSuccess
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgWarning"))
+                val warning: Color = surfaces2.secondary.default.fgWarning
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgError"))
+                val error: Color = surfaces2.secondary.default.fgError
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgWaitingList"))
+                val waitlist: Color = surfaces2.secondary.default.fgWaitingList
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgNeutral"))
+                val neutral: Color = surfaces2.secondary.default.fgNeutral
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgInformation"))
+                val information: Color = surfaces2.secondary.default.fgInformation
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.secondary.default.fgFeatured"))
+                val featured: Color = surfaces2.secondary.default.fgFeatured
+            }
+        }
+
+        class Fixed(surfaces2: Surfaces2) {
+            val primary = Primary(surfaces2)
+            val secondary = Secondary(surfaces2)
+
+            class Primary(surfaces2: Surfaces2) {
+                val bg = Bg(surfaces2)
+                val fg = Fg(surfaces2)
+
+                class Bg(surfaces2: Surfaces2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.bg"))
+                    val default: Color = surfaces2.fixed.primary.default.bg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.selected.bg"))
+                    val selected: Color = surfaces2.fixed.primary.selected.bg
+                }
+
+                class Fg(surfaces2: Surfaces2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fg"))
+                    val default: Color = surfaces2.fixed.primary.default.fg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgAlternate"))
+                    val alternate: Color = surfaces2.fixed.primary.default.fgAlternate
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgDisabled"))
+                    val disabled: Color = surfaces2.fixed.primary.default.fgDisabled
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgSuccess"))
+                    val success: Color = surfaces2.fixed.primary.default.fgSuccess
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgWarning"))
+                    val warning: Color = surfaces2.fixed.primary.default.fgWarning
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgError"))
+                    val error: Color = surfaces2.fixed.primary.default.fgError
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgWaitingList"))
+                    val waitlist: Color = surfaces2.fixed.primary.default.fgWaitingList
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgNeutral"))
+                    val neutral: Color = surfaces2.fixed.primary.default.fgNeutral
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgInformation"))
+                    val information: Color = surfaces2.fixed.primary.default.fgInformation
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.primary.default.fgFeatured"))
+                    val featured: Color = surfaces2.fixed.primary.default.fgFeatured
+                }
+            }
+
+            class Secondary(surfaces2: Surfaces2) {
+                val bg = Bg(surfaces2)
+                val fg = Fg(surfaces2)
+
+                class Bg(surfaces2: Surfaces2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.bg"))
+                    val default: Color = surfaces2.fixed.secondary.default.bg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.selected.bg"))
+                    val selected: Color = surfaces2.fixed.secondary.selected.bg
+                }
+
+                class Fg(surfaces2: Surfaces2) {
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fg"))
+                    val default: Color = surfaces2.fixed.secondary.default.fg
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgAlternate"))
+                    val alternate: Color = surfaces2.fixed.secondary.default.fgAlternate
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgDisabled"))
+                    val disabled: Color = surfaces2.fixed.secondary.default.fgDisabled
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgSuccess"))
+                    val success: Color = surfaces2.fixed.secondary.default.fgSuccess
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgWarning"))
+                    val warning: Color = surfaces2.fixed.secondary.default.fgWarning
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgError"))
+                    val error: Color = surfaces2.fixed.secondary.default.fgError
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgWaitingList"))
+                    val waitlist: Color = surfaces2.fixed.secondary.default.fgWaitingList
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgNeutral"))
+                    val neutral: Color = surfaces2.fixed.secondary.default.fgNeutral
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgInformation"))
+                    val information: Color = surfaces2.fixed.secondary.default.fgInformation
+
+                    @Deprecated("", ReplaceWith("SatsTheme.colors2.surfaces2.fixed.secondary.default.fgFeatured"))
+                    val featured: Color = surfaces2.fixed.secondary.default.fgFeatured
+                }
             }
         }
     }
 
-    class Surfaces(
+    class Surfaces2(
         val primary: Primary,
         val secondary: Secondary,
         val fixed: Fixed,
     ) {
         class Primary(
-            val bg: Bg,
-            val fg: Fg,
-        ) {
-            class Bg(
-                val default: Color,
-                val selected: Color,
-                val disabled: Color,
-            )
-
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-                val disabled: Color,
-                val success: Color,
-                val warning: Color,
-                val error: Color,
-                val waitlist: Color,
-                val neutral: Color,
-                val information: Color,
-                val featured: Color,
-            )
-        }
+            val default: SurfaceColorSet,
+            val selected: SurfaceColorSet,
+            val disabled: SurfaceColorSet,
+        )
 
         class Secondary(
-            val bg: Bg,
-            val fg: Fg,
-        ) {
-            class Bg(
-                val default: Color,
-                val selected: Color,
-            )
-
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-                val disabled: Color,
-                val success: Color,
-                val warning: Color,
-                val error: Color,
-                val waitlist: Color,
-                val neutral: Color,
-                val information: Color,
-                val featured: Color,
-            )
-        }
+            val default: SurfaceColorSet,
+            val selected: SurfaceColorSet,
+        )
 
         class Fixed(
             val primary: Primary,
             val secondary: Secondary,
         ) {
             class Primary(
-                val bg: Bg,
-                val fg: Fg,
-            ) {
-                class Bg(
-                    val default: Color,
-                    val selected: Color,
-                )
-
-                class Fg(
-                    val default: Color,
-                    val alternate: Color,
-                    val disabled: Color,
-                    val success: Color,
-                    val warning: Color,
-                    val error: Color,
-                    val waitlist: Color,
-                    val neutral: Color,
-                    val information: Color,
-                    val featured: Color,
-                )
-            }
+                val default: SurfaceColorSet,
+                val selected: SurfaceColorSet,
+            )
 
             class Secondary(
-                val bg: Bg,
-                val fg: Fg,
-            ) {
-                class Bg(
-                    val default: Color,
-                    val selected: Color,
-                )
+                val default: SurfaceColorSet,
+                val selected: SurfaceColorSet,
+            )
+        }
+    }
 
-                class Fg(
-                    val default: Color,
-                    val alternate: Color,
-                    val disabled: Color,
-                    val success: Color,
-                    val warning: Color,
-                    val error: Color,
-                    val waitlist: Color,
-                    val neutral: Color,
-                    val information: Color,
-                    val featured: Color,
-                )
+    class SignalSurfaces(signalSurfaces2: SignalSurfaces2) {
+        val success = Success(signalSurfaces2)
+        val warning = Warning(signalSurfaces2)
+        val error = Error(signalSurfaces2)
+        val waitingList = WaitingList(signalSurfaces2)
+        val neutral = Neutral(signalSurfaces2)
+        val information = Information(signalSurfaces2)
+        val featured = Featured(signalSurfaces2)
+
+        class Success(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.success.default.bg"))
+            val bg: Color = signalSurfaces2.success.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.success.default.fg"))
+                val default: Color = signalSurfaces2.success.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.success.alternate.fg"))
+                val alternate: Color = signalSurfaces2.success.alternate.fg
+            }
+        }
+
+        class Warning(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.warning.default.bg"))
+            val bg: Color = signalSurfaces2.warning.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.warning.default.fg"))
+                val default: Color = signalSurfaces2.warning.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.warning.alternate.fg"))
+                val alternate: Color = signalSurfaces2.warning.alternate.fg
+            }
+        }
+
+        class Error(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.error.default.bg"))
+            val bg: Color = signalSurfaces2.error.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.error.default.fg"))
+                val default: Color = signalSurfaces2.error.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.error.alternate.fg"))
+                val alternate: Color = signalSurfaces2.error.alternate.fg
+            }
+        }
+
+        class WaitingList(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.waitingList.default.bg"))
+            val bg: Color = signalSurfaces2.waitingList.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.waitingList.default.fg"))
+                val default: Color = signalSurfaces2.waitingList.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.waitingList.alternate.fg"))
+                val alternate: Color = signalSurfaces2.waitingList.alternate.fg
+            }
+        }
+
+        class Neutral(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.neutral.default.bg"))
+            val bg: Color = signalSurfaces2.neutral.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.neutral.default.fg"))
+                val default: Color = signalSurfaces2.neutral.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.neutral.alternate.fg"))
+                val alternate: Color = signalSurfaces2.neutral.alternate.fg
+            }
+        }
+
+        class Information(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.information.default.bg"))
+            val bg: Color = signalSurfaces2.information.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.information.default.fg"))
+                val default: Color = signalSurfaces2.information.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.information.alternate.fg"))
+                val alternate: Color = signalSurfaces2.information.alternate.fg
+            }
+        }
+
+        class Featured(signalSurfaces2: SignalSurfaces2) {
+            @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.featured.default.bg"))
+            val bg: Color = signalSurfaces2.featured.default.bg
+
+            val fg = Fg(signalSurfaces2)
+
+            class Fg(signalSurfaces2: SignalSurfaces2) {
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.featured.default.fg"))
+                val default: Color = signalSurfaces2.featured.default.fg
+
+                @Deprecated("", ReplaceWith("SatsTheme.colors2.signalSurfaces2.featured.alternate.fg"))
+                val alternate: Color = signalSurfaces2.featured.alternate.fg
             }
         }
     }
 
-    class SignalSurfaces(
+    class SignalSurfaces2(
         val success: Success,
         val warning: Warning,
         val error: Error,
@@ -715,73 +824,134 @@ class SatsColors2(
         val featured: Featured,
     ) {
         class Success(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class Warning(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class Error(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class WaitingList(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class Neutral(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class Information(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
 
         class Featured(
-            val bg: Color,
-            val fg: Fg,
-        ) {
-            class Fg(
-                val default: Color,
-                val alternate: Color,
-            )
-        }
+            val default: ColorSet,
+            val alternate: ColorSet,
+        )
+    }
+}
+
+interface ColorSet {
+    val bg: Color
+    val fg: Color
+}
+
+internal fun ColorSet(
+    bg: Color,
+    fg: Color,
+): ColorSet {
+    return object : ColorSet {
+        override val bg = bg
+        override val fg = fg
+    }
+}
+
+interface OutlinedColorSet : ColorSet {
+    override val bg: Color
+    override val fg: Color
+    val outline: Color
+}
+
+internal fun OutlinedColorSet(
+    bg: Color,
+    fg: Color,
+    outline: Color,
+): OutlinedColorSet {
+    return object : OutlinedColorSet {
+        override val bg = bg
+        override val fg = fg
+        override val outline = outline
+    }
+}
+
+interface BackgroundColorSet : ColorSet {
+    override val bg: Color
+    override val fg: Color
+    val fgAlternate: Color
+    val fgDisabled: Color
+}
+
+internal fun BackgroundColorSet(
+    bg: Color,
+    fgDefault: Color,
+    fgAlternate: Color,
+    fgDisabled: Color,
+): BackgroundColorSet {
+    return object : BackgroundColorSet {
+        override val bg = bg
+        override val fg = fgDefault
+        override val fgAlternate = fgAlternate
+        override val fgDisabled = fgDisabled
+    }
+}
+
+interface SurfaceColorSet : ColorSet {
+    override val bg: Color
+    override val fg: Color
+    val fgAlternate: Color
+    val fgDisabled: Color
+    val fgSuccess: Color
+    val fgWarning: Color
+    val fgError: Color
+    val fgWaitingList: Color
+    val fgNeutral: Color
+    val fgInformation: Color
+    val fgFeatured: Color
+}
+
+internal fun SurfaceColorSet(
+    bg: Color,
+    fgDefault: Color,
+    fgAlternate: Color,
+    fgDisabled: Color,
+    fgSuccess: Color,
+    fgWarning: Color,
+    fgError: Color,
+    fgWaitingList: Color,
+    fgNeutral: Color,
+    fgInformation: Color,
+    fgFeatured: Color,
+): SurfaceColorSet {
+    return object : SurfaceColorSet {
+        override val bg = bg
+        override val fg = fgDefault
+        override val fgAlternate = fgAlternate
+        override val fgDisabled = fgDisabled
+        override val fgSuccess = fgSuccess
+        override val fgWarning = fgWarning
+        override val fgError = fgError
+        override val fgWaitingList = fgWaitingList
+        override val fgNeutral = fgNeutral
+        override val fgInformation = fgInformation
+        override val fgFeatured = fgFeatured
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsContentColorFor.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsContentColorFor.kt
@@ -8,9 +8,9 @@ import com.sats.dna.theme.SatsTheme
 fun satsContentColor2For(backgroundColor: Color): Color {
     val buttons = SatsTheme.colors2.buttons
     val graphicalElements = SatsTheme.colors2.graphicalElements
-    val backgrounds = SatsTheme.colors2.backgrounds
-    val surfaces = SatsTheme.colors2.surfaces
-    val signalSurfaces = SatsTheme.colors2.signalSurfaces
+    val backgrounds = SatsTheme.colors2.backgrounds2
+    val surfaces = SatsTheme.colors2.surfaces2
+    val signalSurfaces = SatsTheme.colors2.signalSurfaces2
 
     return when (backgroundColor) {
         buttons.primary.default.bg -> buttons.primary.default.fg
@@ -43,35 +43,35 @@ fun satsContentColor2For(backgroundColor: Color): Color {
         graphicalElements.rewards.gold.bg -> graphicalElements.rewards.gold.bg
         graphicalElements.rewards.platinum.bg -> graphicalElements.rewards.platinum.bg
 
-        backgrounds.primary.bg.default -> backgrounds.primary.fg.default
-        backgrounds.primary.bg.selected -> backgrounds.primary.fg.default
+        backgrounds.primary.default.bg -> backgrounds.primary.default.fg
+        backgrounds.primary.selected.bg -> backgrounds.primary.default.fg
 
-        backgrounds.secondary.bg.default -> backgrounds.secondary.fg.default
-        backgrounds.secondary.bg.selected -> backgrounds.secondary.fg.default
+        backgrounds.secondary.default.bg -> backgrounds.secondary.default.fg
+        backgrounds.secondary.selected.bg -> backgrounds.secondary.default.fg
 
-        backgrounds.fixed.primary.bg.default -> backgrounds.fixed.primary.fg.default
-        backgrounds.fixed.primary.bg.selected -> backgrounds.fixed.primary.fg.default
-        backgrounds.fixed.secondary.bg.default -> backgrounds.fixed.secondary.fg.default
-        backgrounds.fixed.secondary.bg.selected -> backgrounds.fixed.secondary.fg.default
+        backgrounds.fixed.primary.default.bg -> backgrounds.fixed.primary.default.fg
+        backgrounds.fixed.primary.selected.bg -> backgrounds.fixed.primary.default.fg
+        backgrounds.fixed.secondary.default.bg -> backgrounds.fixed.secondary.default.fg
+        backgrounds.fixed.secondary.selected.bg -> backgrounds.fixed.secondary.default.fg
 
-        surfaces.primary.bg.default -> surfaces.primary.fg.default
-        surfaces.primary.bg.selected -> surfaces.primary.fg.default
+        surfaces.primary.default.bg -> surfaces.primary.default.fg
+        surfaces.primary.selected.bg -> surfaces.primary.default.fg
 
-        surfaces.secondary.bg.default -> surfaces.secondary.fg.default
-        surfaces.secondary.bg.selected -> surfaces.secondary.fg.default
+        surfaces.secondary.default.bg -> surfaces.secondary.default.fg
+        surfaces.secondary.selected.bg -> surfaces.secondary.default.fg
 
-        surfaces.fixed.primary.bg.default -> surfaces.fixed.primary.fg.default
-        surfaces.fixed.primary.bg.selected -> surfaces.fixed.primary.fg.default
-        surfaces.fixed.secondary.bg.default -> surfaces.fixed.secondary.fg.default
-        surfaces.fixed.secondary.bg.selected -> surfaces.fixed.secondary.fg.default
+        surfaces.fixed.primary.default.bg -> surfaces.fixed.primary.default.fg
+        surfaces.fixed.primary.selected.bg -> surfaces.fixed.primary.default.fg
+        surfaces.fixed.secondary.default.bg -> surfaces.fixed.secondary.default.fg
+        surfaces.fixed.secondary.selected.bg -> surfaces.fixed.secondary.default.fg
 
-        signalSurfaces.success.bg -> signalSurfaces.success.fg.default
-        signalSurfaces.warning.bg -> signalSurfaces.warning.fg.default
-        signalSurfaces.error.bg -> signalSurfaces.error.fg.default
-        signalSurfaces.waitingList.bg -> signalSurfaces.waitingList.fg.default
-        signalSurfaces.neutral.bg -> signalSurfaces.neutral.fg.default
-        signalSurfaces.information.bg -> signalSurfaces.information.fg.default
-        signalSurfaces.featured.bg -> signalSurfaces.featured.fg.default
+        signalSurfaces.success.default.bg -> signalSurfaces.success.default.fg
+        signalSurfaces.warning.default.bg -> signalSurfaces.warning.default.fg
+        signalSurfaces.error.default.bg -> signalSurfaces.error.default.fg
+        signalSurfaces.waitingList.default.bg -> signalSurfaces.waitingList.default.fg
+        signalSurfaces.neutral.default.bg -> signalSurfaces.neutral.default.fg
+        signalSurfaces.information.default.bg -> signalSurfaces.information.default.fg
+        signalSurfaces.featured.default.bg -> signalSurfaces.featured.default.fg
 
         else -> Color.Unspecified
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors2.kt
@@ -1,93 +1,105 @@
 package com.sats.dna.colors
 
+import androidx.compose.ui.graphics.Color
+
 internal val SatsDarkColors2 = SatsColors2(
     buttons = SatsColors2.Buttons(
         primary = SatsColors2.Buttons.Primary(
-            default = SatsColors2.Buttons.Primary.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue110,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.Primary.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue160,
                 fg = SatsColorPrimitives.Black50,
             ),
         ),
         secondary = SatsColors2.Buttons.Secondary(
-            default = SatsColors2.Buttons.Secondary.Default(
+            default = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.BrightBlue110,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.Secondary.Disabled(
+            disabled = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.Black80,
                 fg = SatsColorPrimitives.Black50,
             ),
         ),
         clean = SatsColors2.Buttons.Clean(
-            default = SatsColors2.Buttons.Clean.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.White100,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            disabled = SatsColors2.Buttons.Clean.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.White10,
                 fg = SatsColorPrimitives.White50,
             ),
         ),
         cleanSecondary = SatsColors2.Buttons.CleanSecondary(
-            default = SatsColors2.Buttons.CleanSecondary.Default(
+            default = OutlinedColorSet(
                 bg = SatsColorPrimitives.White15,
                 outline = SatsColorPrimitives.White100,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.CleanSecondary.Disabled(
+            disabled = OutlinedColorSet(
                 bg = SatsColorPrimitives.White5,
                 outline = SatsColorPrimitives.White40,
                 fg = SatsColorPrimitives.White70,
             ),
         ),
         action = SatsColors2.Buttons.Action(
-            default = SatsColors2.Buttons.Action.Default(
+            default = ColorSet(
+                bg = Color.Transparent,
                 fg = SatsColorPrimitives.SatsCoral,
             ),
-            disabled = SatsColors2.Buttons.Action.Disabled(
+            disabled = ColorSet(
+                bg = Color.Transparent,
                 fg = SatsColorPrimitives.Black50,
             ),
         ),
         waitingListFilled = SatsColors2.Buttons.WaitingListFilled(
-            default = SatsColors2.Buttons.WaitingListFilled.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.EgyptianPurple80,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.WaitingListFilled.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.Black80,
                 fg = SatsColorPrimitives.Black50,
             ),
         ),
         waitingListSecondary = SatsColors2.Buttons.WaitingListSecondary(
-            default = SatsColors2.Buttons.WaitingListSecondary.Default(
+            default = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.EgyptianPurple80,
                 fg = SatsColorPrimitives.EgyptianPurple80,
             ),
-            disabled = SatsColors2.Buttons.WaitingListSecondary.Disabled(
+            disabled = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.Black80,
                 fg = SatsColorPrimitives.Black50,
             ),
         ),
         destructive = SatsColors2.Buttons.Destructive(
             default = SatsColors2.Buttons.Destructive.Default(
-                default = SatsColors2.Buttons.Destructive.Default.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.ChiliRed80,
                     fg = SatsColorPrimitives.White100,
                 ),
-                disabled = SatsColors2.Buttons.Destructive.Default.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.Black80,
                     fg = SatsColorPrimitives.Black50,
                 ),
             ),
             alternate = SatsColors2.Buttons.Destructive.Alternate(
-                default = SatsColors2.Buttons.Destructive.Alternate.Default(
+                default = OutlinedColorSet(
+                    bg = Color.Transparent,
+                    outline = SatsColorPrimitives.ChiliRed80,
                     fg = SatsColorPrimitives.ChiliRed80,
                 ),
-                disabled = SatsColors2.Buttons.Destructive.Alternate.Disabled(
+                disabled = OutlinedColorSet(
+                    bg = Color.Transparent,
+                    outline = SatsColorPrimitives.Black50,
                     fg = SatsColorPrimitives.Black50,
                 ),
             ),
@@ -116,15 +128,25 @@ internal val SatsDarkColors2 = SatsColors2(
             selected = SatsColorPrimitives.White100,
             notSelected = SatsColorPrimitives.White100,
         ),
-        progressBar = SatsColors2.GraphicalElements.ProgressBar(
-            indicator = SatsColorPrimitives.SatsCoral90,
-            indicatorAlternate = SatsColorPrimitives.BrightBlue110,
-            bg = SatsColorPrimitives.Black70,
+        progressBar2 = SatsColors2.GraphicalElements.ProgressBar2(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Black70,
+                fg = SatsColorPrimitives.SatsCoral90,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Black70,
+                fg = SatsColorPrimitives.BrightBlue110,
+            ),
         ),
-        fixedProgressBar = SatsColors2.GraphicalElements.FixedProgressBar(
-            indicator = SatsColorPrimitives.SatsCoral90,
-            indicatorAlternate = SatsColorPrimitives.BrightBlue110,
-            bg = SatsColorPrimitives.White40,
+        fixedProgressBar2 = SatsColors2.GraphicalElements.FixedProgressBar2(
+            default = ColorSet(
+                bg = SatsColorPrimitives.White40,
+                fg = SatsColorPrimitives.SatsCoral90,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.White40,
+                fg = SatsColorPrimitives.BrightBlue110,
+            ),
         ),
         graphs = SatsColors2.GraphicalElements.Graphs(
             bar = SatsColors2.GraphicalElements.Graphs.Bar(
@@ -167,21 +189,21 @@ internal val SatsDarkColors2 = SatsColors2(
         ),
         chips = SatsColors2.GraphicalElements.Chips(
             unselected = SatsColors2.GraphicalElements.Chips.Unselected(
-                default = SatsColors2.GraphicalElements.Chips.Unselected.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.White85,
                     fg = SatsColorPrimitives.BrightBlue110,
                 ),
-                disabled = SatsColors2.GraphicalElements.Chips.Unselected.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.White10,
                     fg = SatsColorPrimitives.White20,
                 ),
             ),
             selected = SatsColors2.GraphicalElements.Chips.Selected(
-                default = SatsColors2.GraphicalElements.Chips.Selected.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.BrightBlue110,
                     fg = SatsColorPrimitives.White100,
                 ),
-                disabled = SatsColors2.GraphicalElements.Chips.Selected.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.Black80,
                     fg = SatsColorPrimitives.White60,
                 ),
@@ -234,265 +256,350 @@ internal val SatsDarkColors2 = SatsColors2(
             waitingList = SatsColorPrimitives.EgyptianPurple80,
         ),
         tags = SatsColors2.GraphicalElements.Tags(
-            primary = SatsColors2.GraphicalElements.Tags.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue110,
                 fg = SatsColorPrimitives.White100,
             ),
-            secondary = SatsColors2.GraphicalElements.Tags.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.Black80,
                 fg = SatsColorPrimitives.White100,
             ),
-            featured = SatsColors2.GraphicalElements.Tags.Featured(
+            featured = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral90,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
         ),
         badge = SatsColors2.GraphicalElements.Badge(
-            primary = SatsColors2.GraphicalElements.Badge.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral90,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            secondary = SatsColors2.GraphicalElements.Badge.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue110,
                 fg = SatsColorPrimitives.White100,
             ),
-            tertiary = SatsColors2.GraphicalElements.Badge.Tertiary(
+            tertiary = ColorSet(
                 bg = SatsColorPrimitives.Black80,
                 fg = SatsColorPrimitives.White100,
             ),
         ),
         fixedBadge = SatsColors2.GraphicalElements.FixedBadge(
-            primary = SatsColors2.GraphicalElements.FixedBadge.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral120,
                 fg = SatsColorPrimitives.White100,
             ),
-            secondary = SatsColors2.GraphicalElements.FixedBadge.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue10,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            tertiary = SatsColors2.GraphicalElements.FixedBadge.Tertiary(
+            tertiary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlueGrey80,
                 fg = SatsColorPrimitives.White100,
             ),
         ),
         rewards = SatsColors2.GraphicalElements.Rewards(
-            blue = SatsColors2.GraphicalElements.Rewards.Blue(
+            blue = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue100,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            silver = SatsColors2.GraphicalElements.Rewards.Silver(
+            silver = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue20,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            gold = SatsColors2.GraphicalElements.Rewards.Gold(
+            gold = ColorSet(
                 bg = SatsColorPrimitives.Gold110,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            platinum = SatsColors2.GraphicalElements.Rewards.Platinum(
+            platinum = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue40,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
         ),
         workouts = SatsColors2.GraphicalElements.Workouts(
-            pt = SatsColors2.GraphicalElements.Workouts.Pt(
+            pt = ColorSet(
                 bg = SatsColorPrimitives.UranianBlue70,
                 fg = SatsColorPrimitives.BrightBlue160,
             ),
-            gx = SatsColors2.GraphicalElements.Workouts.Gx(
+            gx = ColorSet(
                 bg = SatsColorPrimitives.SalmonPink70,
                 fg = SatsColorPrimitives.ChiliRed170,
             ),
-            treatments = SatsColors2.GraphicalElements.Workouts.Treatments(
+            treatments = ColorSet(
                 bg = SatsColorPrimitives.CaribbeanCurrent70,
                 fg = SatsColorPrimitives.SpringGreen10,
             ),
-            gymfloor = SatsColors2.GraphicalElements.Workouts.Gymfloor(
+            gymfloor = ColorSet(
                 bg = SatsColorPrimitives.Tangerine70,
                 fg = SatsColorPrimitives.Gold170,
             ),
-            other = SatsColors2.GraphicalElements.Workouts.Other(
+            other = ColorSet(
                 bg = SatsColorPrimitives.Celadon70,
                 fg = SatsColorPrimitives.SpringGreen170,
             ),
-            bootcamp = SatsColors2.GraphicalElements.Workouts.Bootcamp(
+            bootcamp = ColorSet(
                 bg = SatsColorPrimitives.TropicalIndigo70,
                 fg = SatsColorPrimitives.EgyptianPurple160,
             ),
         ),
     ),
-    backgrounds = SatsColors2.Backgrounds(
-        primary = SatsColors2.Backgrounds.Primary(
-            bg = SatsColors2.Backgrounds.Primary.Bg(
-                default = SatsColorPrimitives.Black,
-                selected = SatsColorPrimitives.Black,
+    backgrounds2 = SatsColors2.Backgrounds2(
+        primary = SatsColors2.Backgrounds2.Primary(
+            default = BackgroundColorSet(
+                bg = SatsColorPrimitives.Black,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
             ),
-            fg = SatsColors2.Backgrounds.Primary.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Black20,
-                disabled = SatsColorPrimitives.Black50,
-            ),
-        ),
-        secondary = SatsColors2.Backgrounds.Secondary(
-            bg = SatsColors2.Backgrounds.Secondary.Bg(
-                default = SatsColorPrimitives.Black90,
-                selected = SatsColorPrimitives.Black90,
-            ),
-            fg = SatsColors2.Backgrounds.Secondary.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Black20,
-                disabled = SatsColorPrimitives.Black50,
+            selected = BackgroundColorSet(
+                bg = SatsColorPrimitives.Black,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
             ),
         ),
-        fixed = SatsColors2.Backgrounds.Fixed(
-            primary = SatsColors2.Backgrounds.Fixed.Primary(
-                bg = SatsColors2.Backgrounds.Fixed.Primary.Bg(
-                    default = SatsColorPrimitives.SatsBlue110,
-                    selected = SatsColorPrimitives.SatsBlue90,
-                ),
-                fg = SatsColors2.Backgrounds.Fixed.Primary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White60,
-                    disabled = SatsColorPrimitives.White40,
-                ),
+        secondary = SatsColors2.Backgrounds2.Secondary(
+            default = BackgroundColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
             ),
-            secondary = SatsColors2.Backgrounds.Fixed.Secondary(
-                bg = SatsColors2.Backgrounds.Fixed.Secondary.Bg(
-                    default = SatsColorPrimitives.SatsBlue,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
-                ),
-                fg = SatsColors2.Backgrounds.Fixed.Secondary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White60,
-                    disabled = SatsColorPrimitives.White40,
-                ),
+            selected = BackgroundColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
             ),
         ),
-    ),
-    surfaces = SatsColors2.Surfaces(
-        primary = SatsColors2.Surfaces.Primary(
-            bg = SatsColors2.Surfaces.Primary.Bg(
-                default = SatsColorPrimitives.Black85,
-                selected = SatsColorPrimitives.BrightBlue160,
-                disabled = SatsColorPrimitives.Black95,
-            ),
-            fg = SatsColors2.Surfaces.Primary.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Black20,
-                disabled = SatsColorPrimitives.Black50,
-                success = SatsColorPrimitives.SpringGreen80,
-                warning = SatsColorPrimitives.Gold80,
-                error = SatsColorPrimitives.Cardinal60,
-                waitlist = SatsColorPrimitives.EgyptianPurple60,
-                neutral = SatsColorPrimitives.Black40,
-                information = SatsColorPrimitives.BrightBlue60,
-                featured = SatsColorPrimitives.SatsCoral90,
-            ),
-        ),
-        secondary = SatsColors2.Surfaces.Secondary(
-            bg = SatsColors2.Surfaces.Secondary.Bg(
-                default = SatsColorPrimitives.Black90,
-                selected = SatsColorPrimitives.Black90,
-            ),
-            fg = SatsColors2.Surfaces.Secondary.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Black20,
-                disabled = SatsColorPrimitives.Black50,
-                success = SatsColorPrimitives.SpringGreen80,
-                warning = SatsColorPrimitives.Gold80,
-                error = SatsColorPrimitives.Cardinal60,
-                waitlist = SatsColorPrimitives.EgyptianPurple60,
-                neutral = SatsColorPrimitives.Black40,
-                information = SatsColorPrimitives.BrightBlue60,
-                featured = SatsColorPrimitives.SatsCoral90,
-            ),
-        ),
-        fixed = SatsColors2.Surfaces.Fixed(
-            primary = SatsColors2.Surfaces.Fixed.Primary(
-                bg = SatsColors2.Surfaces.Fixed.Primary.Bg(
-                    default = SatsColorPrimitives.SatsBlue,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
+        fixed = SatsColors2.Backgrounds2.Fixed(
+            primary = SatsColors2.Backgrounds2.Fixed.Primary(
+                default = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue110,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
-                fg = SatsColors2.Surfaces.Fixed.Primary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White65,
-                    disabled = SatsColorPrimitives.White40,
-                    success = SatsColorPrimitives.SpringGreen60,
-                    warning = SatsColorPrimitives.Gold60,
-                    error = SatsColorPrimitives.Cardinal60,
-                    waitlist = SatsColorPrimitives.EgyptianPurple40,
-                    neutral = SatsColorPrimitives.White60,
-                    information = SatsColorPrimitives.BrightBlue60,
-                    featured = SatsColorPrimitives.SatsCoral60,
+                selected = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue90,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
             ),
-            secondary = SatsColors2.Surfaces.Fixed.Secondary(
-                bg = SatsColors2.Surfaces.Fixed.Secondary.Bg(
-                    default = SatsColorPrimitives.SatsBlueGrey80,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
+            secondary = SatsColors2.Backgrounds2.Fixed.Secondary(
+                default = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
-                fg = SatsColors2.Surfaces.Fixed.Secondary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White65,
-                    disabled = SatsColorPrimitives.White40,
-                    success = SatsColorPrimitives.SpringGreen60,
-                    warning = SatsColorPrimitives.Gold60,
-                    error = SatsColorPrimitives.Cardinal60,
-                    waitlist = SatsColorPrimitives.EgyptianPurple40,
-                    neutral = SatsColorPrimitives.White60,
-                    information = SatsColorPrimitives.BrightBlue60,
-                    featured = SatsColorPrimitives.SatsCoral60,
+                selected = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
             ),
         ),
     ),
-    signalSurfaces = SatsColors2.SignalSurfaces(
-        success = SatsColors2.SignalSurfaces.Success(
-            bg = SatsColorPrimitives.SpringGreen170,
-            fg = SatsColors2.SignalSurfaces.Success.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.SpringGreen80,
+    surfaces2 = SatsColors2.Surfaces2(
+        primary = SatsColors2.Surfaces2.Primary(
+            default = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black85,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
+                fgSuccess = SatsColorPrimitives.SpringGreen80,
+                fgWarning = SatsColorPrimitives.Gold80,
+                fgError = SatsColorPrimitives.Cardinal60,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple60,
+                fgNeutral = SatsColorPrimitives.Black40,
+                fgInformation = SatsColorPrimitives.BrightBlue60,
+                fgFeatured = SatsColorPrimitives.SatsCoral90,
+            ),
+            selected = SurfaceColorSet(
+                bg = SatsColorPrimitives.BrightBlue160,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
+                fgSuccess = SatsColorPrimitives.SpringGreen80,
+                fgWarning = SatsColorPrimitives.Gold80,
+                fgError = SatsColorPrimitives.Cardinal60,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple60,
+                fgNeutral = SatsColorPrimitives.Black40,
+                fgInformation = SatsColorPrimitives.BrightBlue60,
+                fgFeatured = SatsColorPrimitives.SatsCoral90,
+            ),
+            disabled = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black95,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
+                fgSuccess = SatsColorPrimitives.SpringGreen80,
+                fgWarning = SatsColorPrimitives.Gold80,
+                fgError = SatsColorPrimitives.Cardinal60,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple60,
+                fgNeutral = SatsColorPrimitives.Black40,
+                fgInformation = SatsColorPrimitives.BrightBlue60,
+                fgFeatured = SatsColorPrimitives.SatsCoral90,
             ),
         ),
-        warning = SatsColors2.SignalSurfaces.Warning(
-            bg = SatsColorPrimitives.Gold170,
-            fg = SatsColors2.SignalSurfaces.Warning.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Gold80,
+        secondary = SatsColors2.Surfaces2.Secondary(
+            default = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
+                fgSuccess = SatsColorPrimitives.SpringGreen80,
+                fgWarning = SatsColorPrimitives.Gold80,
+                fgError = SatsColorPrimitives.Cardinal60,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple60,
+                fgNeutral = SatsColorPrimitives.Black40,
+                fgInformation = SatsColorPrimitives.BrightBlue60,
+                fgFeatured = SatsColorPrimitives.SatsCoral90,
+            ),
+            selected = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fgDefault = SatsColorPrimitives.White100,
+                fgAlternate = SatsColorPrimitives.Black20,
+                fgDisabled = SatsColorPrimitives.Black50,
+                fgSuccess = SatsColorPrimitives.SpringGreen80,
+                fgWarning = SatsColorPrimitives.Gold80,
+                fgError = SatsColorPrimitives.Cardinal60,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple60,
+                fgNeutral = SatsColorPrimitives.Black40,
+                fgInformation = SatsColorPrimitives.BrightBlue60,
+                fgFeatured = SatsColorPrimitives.SatsCoral90,
             ),
         ),
-        error = SatsColors2.SignalSurfaces.Error(
-            bg = SatsColorPrimitives.Cardinal170,
-            fg = SatsColors2.SignalSurfaces.Error.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Cardinal60,
+        fixed = SatsColors2.Surfaces2.Fixed(
+            primary = SatsColors2.Surfaces2.Fixed.Primary(
+                default = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlue,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+                selected = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+            ),
+            secondary = SatsColors2.Surfaces2.Fixed.Secondary(
+                default = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+                selected = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
             ),
         ),
-        waitingList = SatsColors2.SignalSurfaces.WaitingList(
-            bg = SatsColorPrimitives.EgyptianPurple160,
-            fg = SatsColors2.SignalSurfaces.WaitingList.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.EgyptianPurple60,
+    ),
+    signalSurfaces2 = SatsColors2.SignalSurfaces2(
+        success = SatsColors2.SignalSurfaces2.Success(
+            default = ColorSet(
+                bg = SatsColorPrimitives.SpringGreen170,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.SpringGreen170,
+                fg = SatsColorPrimitives.SpringGreen80,
             ),
         ),
-        neutral = SatsColors2.SignalSurfaces.Neutral(
-            bg = SatsColorPrimitives.Black90,
-            fg = SatsColors2.SignalSurfaces.Neutral.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.Black40,
+        warning = SatsColors2.SignalSurfaces2.Warning(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Gold170,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Gold170,
+                fg = SatsColorPrimitives.Gold80,
             ),
         ),
-        information = SatsColors2.SignalSurfaces.Information(
-            bg = SatsColorPrimitives.BrightBlue160,
-            fg = SatsColors2.SignalSurfaces.Information.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.BrightBlue60,
+        error = SatsColors2.SignalSurfaces2.Error(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Cardinal170,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Cardinal170,
+                fg = SatsColorPrimitives.Cardinal60,
             ),
         ),
-        featured = SatsColors2.SignalSurfaces.Featured(
-            bg = SatsColorPrimitives.SatsCoral190,
-            fg = SatsColors2.SignalSurfaces.Featured.Fg(
-                default = SatsColorPrimitives.White100,
-                alternate = SatsColorPrimitives.SatsCoral90,
+        waitingList = SatsColors2.SignalSurfaces2.WaitingList(
+            default = ColorSet(
+                bg = SatsColorPrimitives.EgyptianPurple160,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.EgyptianPurple160,
+                fg = SatsColorPrimitives.EgyptianPurple60,
+            ),
+        ),
+        neutral = SatsColors2.SignalSurfaces2.Neutral(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Black90,
+                fg = SatsColorPrimitives.Black40,
+            ),
+        ),
+        information = SatsColors2.SignalSurfaces2.Information(
+            default = ColorSet(
+                bg = SatsColorPrimitives.BrightBlue160,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.BrightBlue160,
+                fg = SatsColorPrimitives.BrightBlue60,
+            ),
+        ),
+        featured = SatsColors2.SignalSurfaces2.Featured(
+            default = ColorSet(
+                bg = SatsColorPrimitives.SatsCoral190,
+                fg = SatsColorPrimitives.White100,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.SatsCoral190,
+                fg = SatsColorPrimitives.SatsCoral90,
             ),
         ),
     ),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors2.kt
@@ -1,93 +1,105 @@
 package com.sats.dna.colors
 
+import androidx.compose.ui.graphics.Color
+
 internal val SatsLightColors2 = SatsColors2(
     buttons = SatsColors2.Buttons(
         primary = SatsColors2.Buttons.Primary(
-            default = SatsColors2.Buttons.Primary.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.Primary.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.Black20,
                 fg = SatsColorPrimitives.Black60,
             ),
         ),
         secondary = SatsColors2.Buttons.Secondary(
-            default = SatsColors2.Buttons.Secondary.Default(
+            default = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.SatsBlue,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            disabled = SatsColors2.Buttons.Secondary.Disabled(
+            disabled = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.Black20,
                 fg = SatsColorPrimitives.Black60,
             ),
         ),
         clean = SatsColors2.Buttons.Clean(
-            default = SatsColors2.Buttons.Clean.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.White100,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            disabled = SatsColors2.Buttons.Clean.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.White20,
                 fg = SatsColorPrimitives.White50,
             ),
         ),
         cleanSecondary = SatsColors2.Buttons.CleanSecondary(
-            default = SatsColors2.Buttons.CleanSecondary.Default(
+            default = OutlinedColorSet(
                 bg = SatsColorPrimitives.White15,
                 outline = SatsColorPrimitives.White100,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.CleanSecondary.Disabled(
+            disabled = OutlinedColorSet(
                 bg = SatsColorPrimitives.White5,
                 outline = SatsColorPrimitives.White40,
                 fg = SatsColorPrimitives.White60,
             ),
         ),
         action = SatsColors2.Buttons.Action(
-            default = SatsColors2.Buttons.Action.Default(
+            default = ColorSet(
+                bg = Color.Transparent,
                 fg = SatsColorPrimitives.SatsCoral120,
             ),
-            disabled = SatsColors2.Buttons.Action.Disabled(
+            disabled = ColorSet(
+                bg = Color.Transparent,
                 fg = SatsColorPrimitives.Black20,
             ),
         ),
         waitingListFilled = SatsColors2.Buttons.WaitingListFilled(
-            default = SatsColors2.Buttons.WaitingListFilled.Default(
+            default = ColorSet(
                 bg = SatsColorPrimitives.EgyptianPurple80,
                 fg = SatsColorPrimitives.White100,
             ),
-            disabled = SatsColors2.Buttons.WaitingListFilled.Disabled(
+            disabled = ColorSet(
                 bg = SatsColorPrimitives.Black20,
                 fg = SatsColorPrimitives.Black60,
             ),
         ),
         waitingListSecondary = SatsColors2.Buttons.WaitingListSecondary(
-            default = SatsColors2.Buttons.WaitingListSecondary.Default(
+            default = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.EgyptianPurple80,
                 fg = SatsColorPrimitives.EgyptianPurple80,
             ),
-            disabled = SatsColors2.Buttons.WaitingListSecondary.Disabled(
+            disabled = OutlinedColorSet(
+                bg = Color.Transparent,
                 outline = SatsColorPrimitives.Black20,
                 fg = SatsColorPrimitives.Black20,
             ),
         ),
         destructive = SatsColors2.Buttons.Destructive(
             default = SatsColors2.Buttons.Destructive.Default(
-                default = SatsColors2.Buttons.Destructive.Default.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.ChiliRed100,
                     fg = SatsColorPrimitives.White100,
                 ),
-                disabled = SatsColors2.Buttons.Destructive.Default.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.Black20,
                     fg = SatsColorPrimitives.Black60,
                 ),
             ),
             alternate = SatsColors2.Buttons.Destructive.Alternate(
-                default = SatsColors2.Buttons.Destructive.Alternate.Default(
+                default = OutlinedColorSet(
+                    bg = Color.Transparent,
+                    outline = SatsColorPrimitives.ChiliRed100,
                     fg = SatsColorPrimitives.ChiliRed100,
                 ),
-                disabled = SatsColors2.Buttons.Destructive.Alternate.Disabled(
+                disabled = OutlinedColorSet(
+                    bg = Color.Transparent,
+                    outline = SatsColorPrimitives.Black60,
                     fg = SatsColorPrimitives.Black60,
                 ),
             ),
@@ -116,15 +128,25 @@ internal val SatsLightColors2 = SatsColors2(
             selected = SatsColorPrimitives.SatsBlue,
             notSelected = SatsColorPrimitives.SatsBlue,
         ),
-        progressBar = SatsColors2.GraphicalElements.ProgressBar(
-            indicator = SatsColorPrimitives.SatsCoral,
-            indicatorAlternate = SatsColorPrimitives.SatsBlue,
-            bg = SatsColorPrimitives.SatsLightGrey15,
+        progressBar2 = SatsColors2.GraphicalElements.ProgressBar2(
+            default = ColorSet(
+                bg = SatsColorPrimitives.SatsLightGrey15,
+                fg = SatsColorPrimitives.SatsCoral,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.SatsLightGrey15,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
         ),
-        fixedProgressBar = SatsColors2.GraphicalElements.FixedProgressBar(
-            indicator = SatsColorPrimitives.SatsCoral90,
-            indicatorAlternate = SatsColorPrimitives.BrightBlue110,
-            bg = SatsColorPrimitives.White40,
+        fixedProgressBar2 = SatsColors2.GraphicalElements.FixedProgressBar2(
+            default = ColorSet(
+                bg = SatsColorPrimitives.White40,
+                fg = SatsColorPrimitives.SatsCoral90,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.White40,
+                fg = SatsColorPrimitives.BrightBlue110,
+            ),
         ),
         graphs = SatsColors2.GraphicalElements.Graphs(
             bar = SatsColors2.GraphicalElements.Graphs.Bar(
@@ -167,21 +189,21 @@ internal val SatsLightColors2 = SatsColors2(
         ),
         chips = SatsColors2.GraphicalElements.Chips(
             unselected = SatsColors2.GraphicalElements.Chips.Unselected(
-                default = SatsColors2.GraphicalElements.Chips.Unselected.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.SatsBlue40,
                     fg = SatsColorPrimitives.SatsBlue,
                 ),
-                disabled = SatsColors2.GraphicalElements.Chips.Unselected.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.SatsLightGrey15,
                     fg = SatsColorPrimitives.Black40,
                 ),
             ),
             selected = SatsColors2.GraphicalElements.Chips.Selected(
-                default = SatsColors2.GraphicalElements.Chips.Selected.Default(
+                default = ColorSet(
                     bg = SatsColorPrimitives.SatsBlue,
                     fg = SatsColorPrimitives.White100,
                 ),
-                disabled = SatsColors2.GraphicalElements.Chips.Selected.Disabled(
+                disabled = ColorSet(
                     bg = SatsColorPrimitives.SatsLightGrey15,
                     fg = SatsColorPrimitives.SatsBlue70,
                 ),
@@ -234,265 +256,350 @@ internal val SatsLightColors2 = SatsColors2(
             waitingList = SatsColorPrimitives.EgyptianPurple100,
         ),
         tags = SatsColors2.GraphicalElements.Tags(
-            primary = SatsColors2.GraphicalElements.Tags.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue,
                 fg = SatsColorPrimitives.White100,
             ),
-            secondary = SatsColors2.GraphicalElements.Tags.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue5,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            featured = SatsColors2.GraphicalElements.Tags.Featured(
+            featured = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral120,
                 fg = SatsColorPrimitives.White100,
             ),
         ),
         badge = SatsColors2.GraphicalElements.Badge(
-            primary = SatsColors2.GraphicalElements.Badge.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral120,
                 fg = SatsColorPrimitives.White100,
             ),
-            secondary = SatsColors2.GraphicalElements.Badge.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue,
                 fg = SatsColorPrimitives.White100,
             ),
-            tertiary = SatsColors2.GraphicalElements.Badge.Tertiary(
+            tertiary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue5,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
         ),
         fixedBadge = SatsColors2.GraphicalElements.FixedBadge(
-            primary = SatsColors2.GraphicalElements.FixedBadge.Primary(
+            primary = ColorSet(
                 bg = SatsColorPrimitives.SatsCoral120,
                 fg = SatsColorPrimitives.White100,
             ),
-            secondary = SatsColors2.GraphicalElements.FixedBadge.Secondary(
+            secondary = ColorSet(
                 bg = SatsColorPrimitives.BrightBlue10,
                 fg = SatsColorPrimitives.SatsBlue,
             ),
-            tertiary = SatsColors2.GraphicalElements.FixedBadge.Tertiary(
+            tertiary = ColorSet(
                 bg = SatsColorPrimitives.SatsBlueGrey80,
                 fg = SatsColorPrimitives.White100,
             ),
         ),
         rewards = SatsColors2.GraphicalElements.Rewards(
-            blue = SatsColors2.GraphicalElements.Rewards.Blue(
+            blue = ColorSet(
                 bg = SatsColorPrimitives.SatsBlue,
                 fg = SatsColorPrimitives.White100,
             ),
-            silver = SatsColors2.GraphicalElements.Rewards.Silver(
+            silver = ColorSet(
                 bg = SatsColorPrimitives.Black50,
                 fg = SatsColorPrimitives.White100,
             ),
-            gold = SatsColors2.GraphicalElements.Rewards.Gold(
+            gold = ColorSet(
                 bg = SatsColorPrimitives.Gold130,
                 fg = SatsColorPrimitives.White100,
             ),
-            platinum = SatsColors2.GraphicalElements.Rewards.Platinum(
+            platinum = ColorSet(
                 bg = SatsColorPrimitives.SatsBlueGrey80,
                 fg = SatsColorPrimitives.White100,
             ),
         ),
         workouts = SatsColors2.GraphicalElements.Workouts(
-            pt = SatsColors2.GraphicalElements.Workouts.Pt(
+            pt = ColorSet(
                 bg = SatsColorPrimitives.UranianBlue100,
                 fg = SatsColorPrimitives.BrightBlue160,
             ),
-            gx = SatsColors2.GraphicalElements.Workouts.Gx(
+            gx = ColorSet(
                 bg = SatsColorPrimitives.SalmonPink100,
                 fg = SatsColorPrimitives.ChiliRed170,
             ),
-            treatments = SatsColors2.GraphicalElements.Workouts.Treatments(
+            treatments = ColorSet(
                 bg = SatsColorPrimitives.CaribbeanCurrent100,
                 fg = SatsColorPrimitives.SpringGreen10,
             ),
-            gymfloor = SatsColors2.GraphicalElements.Workouts.Gymfloor(
+            gymfloor = ColorSet(
                 bg = SatsColorPrimitives.Tangerine100,
                 fg = SatsColorPrimitives.Gold170,
             ),
-            other = SatsColors2.GraphicalElements.Workouts.Other(
+            other = ColorSet(
                 bg = SatsColorPrimitives.Celadon100,
                 fg = SatsColorPrimitives.SpringGreen170,
             ),
-            bootcamp = SatsColors2.GraphicalElements.Workouts.Bootcamp(
+            bootcamp = ColorSet(
                 bg = SatsColorPrimitives.TropicalIndigo100,
                 fg = SatsColorPrimitives.EgyptianPurple160,
             ),
         ),
     ),
-    backgrounds = SatsColors2.Backgrounds(
-        primary = SatsColors2.Backgrounds.Primary(
-            bg = SatsColors2.Backgrounds.Primary.Bg(
-                default = SatsColorPrimitives.SatsBlue5,
-                selected = SatsColorPrimitives.SatsBlue5,
+    backgrounds2 = SatsColors2.Backgrounds2(
+        primary = SatsColors2.Backgrounds2.Primary(
+            default = BackgroundColorSet(
+                bg = SatsColorPrimitives.SatsBlue5,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
             ),
-            fg = SatsColors2.Backgrounds.Primary.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SatsBlue70,
-                disabled = SatsColorPrimitives.Black60,
-            ),
-        ),
-        secondary = SatsColors2.Backgrounds.Secondary(
-            bg = SatsColors2.Backgrounds.Secondary.Bg(
-                default = SatsColorPrimitives.White100,
-                selected = SatsColorPrimitives.White100,
-            ),
-            fg = SatsColors2.Backgrounds.Secondary.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SatsBlue70,
-                disabled = SatsColorPrimitives.Black60,
+            selected = BackgroundColorSet(
+                bg = SatsColorPrimitives.SatsBlue5,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
             ),
         ),
-        fixed = SatsColors2.Backgrounds.Fixed(
-            primary = SatsColors2.Backgrounds.Fixed.Primary(
-                bg = SatsColors2.Backgrounds.Fixed.Primary.Bg(
-                    default = SatsColorPrimitives.SatsBlue110,
-                    selected = SatsColorPrimitives.SatsBlue90,
-                ),
-                fg = SatsColors2.Backgrounds.Fixed.Primary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White60,
-                    disabled = SatsColorPrimitives.White40,
-                ),
+        secondary = SatsColors2.Backgrounds2.Secondary(
+            default = BackgroundColorSet(
+                bg = SatsColorPrimitives.White100,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
             ),
-            secondary = SatsColors2.Backgrounds.Fixed.Secondary(
-                bg = SatsColors2.Backgrounds.Fixed.Secondary.Bg(
-                    default = SatsColorPrimitives.SatsBlue,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
-                ),
-                fg = SatsColors2.Backgrounds.Fixed.Secondary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White60,
-                    disabled = SatsColorPrimitives.White40,
-                ),
+            selected = BackgroundColorSet(
+                bg = SatsColorPrimitives.White100,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
             ),
         ),
-    ),
-    surfaces = SatsColors2.Surfaces(
-        primary = SatsColors2.Surfaces.Primary(
-            bg = SatsColors2.Surfaces.Primary.Bg(
-                default = SatsColorPrimitives.White100,
-                selected = SatsColorPrimitives.BrightBlue20,
-                disabled = SatsColorPrimitives.SatsBlue10,
-            ),
-            fg = SatsColors2.Surfaces.Primary.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SatsBlue70,
-                disabled = SatsColorPrimitives.Black60,
-                success = SatsColorPrimitives.SpringGreen120,
-                warning = SatsColorPrimitives.Gold140,
-                error = SatsColorPrimitives.Cardinal120,
-                waitlist = SatsColorPrimitives.EgyptianPurple100,
-                neutral = SatsColorPrimitives.Black60,
-                information = SatsColorPrimitives.BrightBlue110,
-                featured = SatsColorPrimitives.SatsCoral120,
-            ),
-        ),
-        secondary = SatsColors2.Surfaces.Secondary(
-            bg = SatsColors2.Surfaces.Secondary.Bg(
-                default = SatsColorPrimitives.Black5,
-                selected = SatsColorPrimitives.Black5,
-            ),
-            fg = SatsColors2.Surfaces.Secondary.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SatsBlue70,
-                disabled = SatsColorPrimitives.Black60,
-                success = SatsColorPrimitives.SpringGreen120,
-                warning = SatsColorPrimitives.Gold140,
-                error = SatsColorPrimitives.Cardinal120,
-                waitlist = SatsColorPrimitives.EgyptianPurple100,
-                neutral = SatsColorPrimitives.Black60,
-                information = SatsColorPrimitives.BrightBlue110,
-                featured = SatsColorPrimitives.SatsCoral120,
-            ),
-        ),
-        fixed = SatsColors2.Surfaces.Fixed(
-            primary = SatsColors2.Surfaces.Fixed.Primary(
-                bg = SatsColors2.Surfaces.Fixed.Primary.Bg(
-                    default = SatsColorPrimitives.SatsBlue,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
+        fixed = SatsColors2.Backgrounds2.Fixed(
+            primary = SatsColors2.Backgrounds2.Fixed.Primary(
+                default = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue110,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
-                fg = SatsColors2.Surfaces.Fixed.Primary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White65,
-                    disabled = SatsColorPrimitives.White40,
-                    success = SatsColorPrimitives.SpringGreen60,
-                    warning = SatsColorPrimitives.Gold60,
-                    error = SatsColorPrimitives.Cardinal60,
-                    waitlist = SatsColorPrimitives.EgyptianPurple40,
-                    neutral = SatsColorPrimitives.White60,
-                    information = SatsColorPrimitives.BrightBlue60,
-                    featured = SatsColorPrimitives.SatsCoral60,
+                selected = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue90,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
             ),
-            secondary = SatsColors2.Surfaces.Fixed.Secondary(
-                bg = SatsColors2.Surfaces.Fixed.Secondary.Bg(
-                    default = SatsColorPrimitives.SatsBlueGrey80,
-                    selected = SatsColorPrimitives.SatsBlueGrey80,
+            secondary = SatsColors2.Backgrounds2.Fixed.Secondary(
+                default = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlue,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
-                fg = SatsColors2.Surfaces.Fixed.Secondary.Fg(
-                    default = SatsColorPrimitives.White100,
-                    alternate = SatsColorPrimitives.White65,
-                    disabled = SatsColorPrimitives.White40,
-                    success = SatsColorPrimitives.SpringGreen60,
-                    warning = SatsColorPrimitives.Gold60,
-                    error = SatsColorPrimitives.Cardinal60,
-                    waitlist = SatsColorPrimitives.EgyptianPurple40,
-                    neutral = SatsColorPrimitives.White60,
-                    information = SatsColorPrimitives.BrightBlue60,
-                    featured = SatsColorPrimitives.SatsCoral60,
+                selected = BackgroundColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White60,
+                    fgDisabled = SatsColorPrimitives.White40,
                 ),
             ),
         ),
     ),
-    signalSurfaces = SatsColors2.SignalSurfaces(
-        success = SatsColors2.SignalSurfaces.Success(
-            bg = SatsColorPrimitives.SpringGreen10,
-            fg = SatsColors2.SignalSurfaces.Success.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SpringGreen120,
+    surfaces2 = SatsColors2.Surfaces2(
+        primary = SatsColors2.Surfaces2.Primary(
+            default = SurfaceColorSet(
+                bg = SatsColorPrimitives.White100,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
+                fgSuccess = SatsColorPrimitives.SpringGreen120,
+                fgWarning = SatsColorPrimitives.Gold140,
+                fgError = SatsColorPrimitives.Cardinal120,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple100,
+                fgNeutral = SatsColorPrimitives.Black60,
+                fgInformation = SatsColorPrimitives.BrightBlue110,
+                fgFeatured = SatsColorPrimitives.SatsCoral120,
+            ),
+            selected = SurfaceColorSet(
+                bg = SatsColorPrimitives.BrightBlue20,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
+                fgSuccess = SatsColorPrimitives.SpringGreen120,
+                fgWarning = SatsColorPrimitives.Gold140,
+                fgError = SatsColorPrimitives.Cardinal120,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple100,
+                fgNeutral = SatsColorPrimitives.Black60,
+                fgInformation = SatsColorPrimitives.BrightBlue110,
+                fgFeatured = SatsColorPrimitives.SatsCoral120,
+            ),
+            disabled = SurfaceColorSet(
+                bg = SatsColorPrimitives.SatsBlue10,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
+                fgSuccess = SatsColorPrimitives.SpringGreen120,
+                fgWarning = SatsColorPrimitives.Gold140,
+                fgError = SatsColorPrimitives.Cardinal120,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple100,
+                fgNeutral = SatsColorPrimitives.Black60,
+                fgInformation = SatsColorPrimitives.BrightBlue110,
+                fgFeatured = SatsColorPrimitives.SatsCoral120,
             ),
         ),
-        warning = SatsColors2.SignalSurfaces.Warning(
-            bg = SatsColorPrimitives.Gold10,
-            fg = SatsColors2.SignalSurfaces.Warning.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.Gold140,
+        secondary = SatsColors2.Surfaces2.Secondary(
+            default = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black5,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
+                fgSuccess = SatsColorPrimitives.SpringGreen120,
+                fgWarning = SatsColorPrimitives.Gold140,
+                fgError = SatsColorPrimitives.Cardinal120,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple100,
+                fgNeutral = SatsColorPrimitives.Black60,
+                fgInformation = SatsColorPrimitives.BrightBlue110,
+                fgFeatured = SatsColorPrimitives.SatsCoral120,
+            ),
+            selected = SurfaceColorSet(
+                bg = SatsColorPrimitives.Black5,
+                fgDefault = SatsColorPrimitives.SatsBlue,
+                fgAlternate = SatsColorPrimitives.SatsBlue70,
+                fgDisabled = SatsColorPrimitives.Black60,
+                fgSuccess = SatsColorPrimitives.SpringGreen120,
+                fgWarning = SatsColorPrimitives.Gold140,
+                fgError = SatsColorPrimitives.Cardinal120,
+                fgWaitingList = SatsColorPrimitives.EgyptianPurple100,
+                fgNeutral = SatsColorPrimitives.Black60,
+                fgInformation = SatsColorPrimitives.BrightBlue110,
+                fgFeatured = SatsColorPrimitives.SatsCoral120,
             ),
         ),
-        error = SatsColors2.SignalSurfaces.Error(
-            bg = SatsColorPrimitives.Cardinal10,
-            fg = SatsColors2.SignalSurfaces.Error.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.Cardinal120,
+        fixed = SatsColors2.Surfaces2.Fixed(
+            primary = SatsColors2.Surfaces2.Fixed.Primary(
+                default = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlue,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+                selected = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+            ),
+            secondary = SatsColors2.Surfaces2.Fixed.Secondary(
+                default = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
+                selected = SurfaceColorSet(
+                    bg = SatsColorPrimitives.SatsBlueGrey80,
+                    fgDefault = SatsColorPrimitives.White100,
+                    fgAlternate = SatsColorPrimitives.White65,
+                    fgDisabled = SatsColorPrimitives.White40,
+                    fgSuccess = SatsColorPrimitives.SpringGreen60,
+                    fgWarning = SatsColorPrimitives.Gold60,
+                    fgError = SatsColorPrimitives.Cardinal60,
+                    fgWaitingList = SatsColorPrimitives.EgyptianPurple40,
+                    fgNeutral = SatsColorPrimitives.White60,
+                    fgInformation = SatsColorPrimitives.BrightBlue60,
+                    fgFeatured = SatsColorPrimitives.SatsCoral60,
+                ),
             ),
         ),
-        waitingList = SatsColors2.SignalSurfaces.WaitingList(
-            bg = SatsColorPrimitives.EgyptianPurple10,
-            fg = SatsColors2.SignalSurfaces.WaitingList.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.EgyptianPurple100,
+    ),
+    signalSurfaces2 = SatsColors2.SignalSurfaces2(
+        success = SatsColors2.SignalSurfaces2.Success(
+            default = ColorSet(
+                bg = SatsColorPrimitives.SpringGreen10,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.SpringGreen10,
+                fg = SatsColorPrimitives.SpringGreen120,
             ),
         ),
-        neutral = SatsColors2.SignalSurfaces.Neutral(
-            bg = SatsColorPrimitives.Black5,
-            fg = SatsColors2.SignalSurfaces.Neutral.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.Black60,
+        warning = SatsColors2.SignalSurfaces2.Warning(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Gold10,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Gold10,
+                fg = SatsColorPrimitives.Gold140,
             ),
         ),
-        information = SatsColors2.SignalSurfaces.Information(
-            bg = SatsColorPrimitives.BrightBlue10,
-            fg = SatsColors2.SignalSurfaces.Information.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.BrightBlue110,
+        error = SatsColors2.SignalSurfaces2.Error(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Cardinal10,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Cardinal10,
+                fg = SatsColorPrimitives.Cardinal120,
             ),
         ),
-        featured = SatsColors2.SignalSurfaces.Featured(
-            bg = SatsColorPrimitives.SatsCoral5,
-            fg = SatsColors2.SignalSurfaces.Featured.Fg(
-                default = SatsColorPrimitives.SatsBlue,
-                alternate = SatsColorPrimitives.SatsCoral,
+        waitingList = SatsColors2.SignalSurfaces2.WaitingList(
+            default = ColorSet(
+                bg = SatsColorPrimitives.EgyptianPurple10,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.EgyptianPurple10,
+                fg = SatsColorPrimitives.EgyptianPurple100,
+            ),
+        ),
+        neutral = SatsColors2.SignalSurfaces2.Neutral(
+            default = ColorSet(
+                bg = SatsColorPrimitives.Black5,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.Black5,
+                fg = SatsColorPrimitives.Black60,
+            ),
+        ),
+        information = SatsColors2.SignalSurfaces2.Information(
+            default = ColorSet(
+                bg = SatsColorPrimitives.BrightBlue10,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.BrightBlue10,
+                fg = SatsColorPrimitives.BrightBlue110,
+            ),
+        ),
+        featured = SatsColors2.SignalSurfaces2.Featured(
+            default = ColorSet(
+                bg = SatsColorPrimitives.SatsCoral5,
+                fg = SatsColorPrimitives.SatsBlue,
+            ),
+            alternate = ColorSet(
+                bg = SatsColorPrimitives.SatsCoral5,
+                fg = SatsColorPrimitives.SatsCoral,
             ),
         ),
     ),

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBadge.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBadge.kt
@@ -96,8 +96,15 @@ private val SatsBadgeHierarchy.fixedContentColor: Color
 @Composable
 private fun SatsBadgePrimaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Primary)
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsBadge(
+                "5",
+                Modifier.padding(SatsTheme.spacing.m),
+                hierarchy = SatsBadgeHierarchy.Primary,
+            )
         }
     }
 }
@@ -106,8 +113,15 @@ private fun SatsBadgePrimaryPreview() {
 @Composable
 private fun SatsBadgeSecondaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Secondary)
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsBadge(
+                "5",
+                Modifier.padding(SatsTheme.spacing.m),
+                hierarchy = SatsBadgeHierarchy.Secondary,
+            )
         }
     }
 }
@@ -116,8 +130,15 @@ private fun SatsBadgeSecondaryPreview() {
 @Composable
 private fun SatsBadgeTertiaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Tertiary)
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsBadge(
+                "5",
+                Modifier.padding(SatsTheme.spacing.m),
+                hierarchy = SatsBadgeHierarchy.Tertiary,
+            )
         }
     }
 }
@@ -126,7 +147,7 @@ private fun SatsBadgeTertiaryPreview() {
 @Composable
 private fun SatsFixedBadgePrimaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg, useMaterial3 = true) {
             SatsFixedBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Primary)
         }
     }
@@ -136,7 +157,7 @@ private fun SatsFixedBadgePrimaryPreview() {
 @Composable
 private fun SatsFixedBadgeSecondaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg, useMaterial3 = true) {
             SatsFixedBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Secondary)
         }
     }
@@ -146,7 +167,7 @@ private fun SatsFixedBadgeSecondaryPreview() {
 @Composable
 private fun SatsFixedBadgeTertiaryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg, useMaterial3 = true) {
             SatsFixedBadge("5", Modifier.padding(SatsTheme.spacing.m), hierarchy = SatsBadgeHierarchy.Tertiary)
         }
     }
@@ -156,7 +177,10 @@ private fun SatsFixedBadgeTertiaryPreview() {
 @Composable
 private fun SatsBadgeFontScalePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBadge("5", Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBanner.kt
@@ -22,7 +22,7 @@ fun SatsBanner(
 ) {
     SatsSurface(
         modifier = modifier,
-        color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default,
+        color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
     ) {
         Row(
             Modifier.padding(horizontal = SatsTheme.spacing.m, vertical = SatsTheme.spacing.xs),
@@ -65,7 +65,10 @@ private val SatsBannerAction.composable: @Composable () -> Unit
 @Composable
 private fun SatsBannerPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBanner(
                 modifier = Modifier.fillMaxWidth(),
                 title = "Will the real Slim Shady please stand up?",
@@ -78,7 +81,10 @@ private fun SatsBannerPreview() {
 @Composable
 private fun SatsBannerWithActionPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBanner(
                 modifier = Modifier.fillMaxWidth(),
                 title = "Will the real Slim Shady please stand up?",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBrandLogo.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsBrandLogo.kt
@@ -50,7 +50,10 @@ private fun SatsBrandLogoBrand.fullNameIconPainter() = when (this) {
 @Composable
 private fun SatsBrandLogoElixiaLetterPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBrandLogo(
                 brand = SatsBrandLogoBrand.Elixia,
                 contentDescription = null,
@@ -64,7 +67,10 @@ private fun SatsBrandLogoElixiaLetterPreview() {
 @Composable
 private fun SatsBrandLogoElixiaFullPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBrandLogo(
                 brand = SatsBrandLogoBrand.Elixia,
                 contentDescription = null,
@@ -79,7 +85,10 @@ private fun SatsBrandLogoElixiaFullPreview() {
 @Composable
 private fun SatsBrandLogoSatsLetterPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBrandLogo(
                 brand = SatsBrandLogoBrand.Sats,
                 contentDescription = null,
@@ -93,7 +102,10 @@ private fun SatsBrandLogoSatsLetterPreview() {
 @Composable
 private fun SatsBrandLogoSatsFullPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBrandLogo(
                 brand = SatsBrandLogoBrand.Sats,
                 contentDescription = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
@@ -23,7 +23,7 @@ fun SatsChallengeBackground(modifier: Modifier = Modifier, isEnabled: Boolean = 
         } else {
             modifier
         },
-        color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default,
+        color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
         useMaterial3 = true,
     ) {
         Box {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBadge.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBadge.kt
@@ -30,7 +30,7 @@ fun SatsChallengeBadge(
                 modifier = Modifier.fillMaxSize(),
                 progress = progress,
                 strokeWidth = 2.dp,
-                color = SatsTheme.colors2.graphicalElements.progressBar.indicator,
+                color = SatsTheme.colors2.graphicalElements.progressBar2.default.fg,
             )
         }
 
@@ -63,7 +63,7 @@ private fun ErrorFallback(contentDescription: String?, modifier: Modifier = Modi
 @Composable
 private fun SatsChallengeBadgePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsChallengeBadge(
                 imageUrl = null,
                 contentDescription = null,
@@ -79,7 +79,7 @@ private fun SatsChallengeBadgePreview() {
 @Composable
 private fun SatsChallengeBadgeProgressPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsChallengeBadge(
                 imageUrl = null,
                 contentDescription = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCheckbox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCheckbox.kt
@@ -81,7 +81,7 @@ private val fixedColors
 @Composable
 private fun BooleanEnabledCheckedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCheckbox(
                 checked = true,
                 onCheckedChange = null,
@@ -95,7 +95,7 @@ private fun BooleanEnabledCheckedPreview() {
 @Composable
 private fun BooleanEnabledUncheckedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCheckbox(
                 checked = false,
                 onCheckedChange = null,
@@ -109,7 +109,7 @@ private fun BooleanEnabledUncheckedPreview() {
 @Composable
 private fun BooleanDisabledCheckedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCheckbox(
                 checked = true,
                 onCheckedChange = null,
@@ -124,7 +124,7 @@ private fun BooleanDisabledCheckedPreview() {
 @Composable
 private fun BooleanDisabledUncheckedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCheckbox(
                 checked = false,
                 onCheckedChange = null,
@@ -139,7 +139,10 @@ private fun BooleanDisabledUncheckedPreview() {
 @Composable
 private fun BooleanEnabledCheckedFixedColorsPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsCheckbox(
                 checked = true,
                 onCheckedChange = null,
@@ -154,7 +157,10 @@ private fun BooleanEnabledCheckedFixedColorsPreview() {
 @Composable
 private fun BooleanEnabledUncheckedFixedColorsPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsCheckbox(
                 checked = false,
                 onCheckedChange = null,
@@ -169,7 +175,10 @@ private fun BooleanEnabledUncheckedFixedColorsPreview() {
 @Composable
 private fun BooleanDisabledCheckedFixedColorsPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsCheckbox(
                 checked = true,
                 onCheckedChange = null,
@@ -185,7 +194,10 @@ private fun BooleanDisabledCheckedFixedColorsPreview() {
 @Composable
 private fun BooleanDisabledUncheckedFixedColorsPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsCheckbox(
                 checked = false,
                 onCheckedChange = null,
@@ -203,7 +215,7 @@ private fun TriStateEnabledDefaultPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,
 ) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsTriStateCheckbox(
                 state = state,
                 onClick = null,
@@ -220,7 +232,7 @@ private fun TriStateDisabledDefaultPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,
 ) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsTriStateCheckbox(
                 state = state,
                 onClick = null,
@@ -237,7 +249,10 @@ private fun TriStateEnabledFixedColorPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,
 ) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTriStateCheckbox(
                 state = state,
                 onClick = null,
@@ -255,7 +270,10 @@ private fun TriStateDisabledFixedColorPreview(
     @PreviewParameter(ToggleableStatePreviewProvider::class) state: ToggleableState,
 ) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.fixed.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.fixed.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTriStateCheckbox(
                 state = state,
                 onClick = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChip.kt
@@ -168,7 +168,10 @@ private fun SatsChipLayout(
 @Composable
 private fun SatsFilterChipPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             Column {
                 Row(
                     Modifier.padding(SatsTheme.spacing.m),
@@ -222,7 +225,7 @@ private fun SatsInputChipPreview() {
     SatsTheme {
         SatsSurface(
             Modifier.width(250.dp),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             Column(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCircularProgressIndicator.kt
@@ -20,7 +20,7 @@ fun SatsCircularProgressIndicator(
 ) {
     CircularProgressIndicator(
         modifier = modifier,
-        color = SatsTheme.colors2.graphicalElements.progressBar.indicator,
+        color = SatsTheme.colors2.graphicalElements.progressBar2.default.fg,
         strokeWidth = strokeWidth,
         trackColor = Color.Transparent,
         strokeCap = StrokeCap.Round,
@@ -31,11 +31,11 @@ fun SatsCircularProgressIndicator(
 fun SatsCircularProgressIndicator(
     progress: Float,
     modifier: Modifier = Modifier,
-    color: Color = SatsTheme.colors2.graphicalElements.progressBar.indicator,
+    color: Color = SatsTheme.colors2.graphicalElements.progressBar2.default.fg,
     strokeWidth: Dp = 4.dp,
 ) {
     CircularProgressIndicator(
-        progress = progress,
+        progress = { progress },
         modifier = modifier,
         color = color,
         strokeWidth = strokeWidth,
@@ -48,7 +48,7 @@ fun SatsCircularProgressIndicator(
 @Composable
 private fun SatsCircularProgressIndicatorPreview(@PreviewParameter(ProgressPreviewProvider::class) progress: Float) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCircularProgressIndicator(progress, Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCompletedWorkoutListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsCompletedWorkoutListItem.kt
@@ -90,10 +90,10 @@ private fun SocialRow(
                 MaterialIcon(
                     SatsTheme.icons.fistBump,
                     contentDescription = null,
-                    tint = SatsTheme.colors2.backgrounds.secondary.fg.default,
+                    tint = SatsTheme.colors2.backgrounds2.secondary.default.fg,
                 )
 
-                MaterialText(numberOfReactionsLabel, color = SatsTheme.colors2.backgrounds.secondary.fg.default)
+                MaterialText(numberOfReactionsLabel, color = SatsTheme.colors2.backgrounds2.secondary.default.fg)
             }
         }
 
@@ -112,7 +112,7 @@ private fun SocialRow(
                     contentDescription = null,
                     tint = SatsTheme.colors2.buttons.action.default.fg,
                 )
-                MaterialText(normalizedNumberOfComments, color = SatsTheme.colors2.backgrounds.secondary.fg.default)
+                MaterialText(normalizedNumberOfComments, color = SatsTheme.colors2.backgrounds2.secondary.default.fg)
             }
 
             SatsLikeButton(isLiked = isLiked, onSaidAwesomeClicked)
@@ -130,7 +130,7 @@ private fun WorkoutInfo(
     Column(modifier) {
         MaterialText(
             timestamp,
-            color = SatsTheme.colors2.backgrounds.secondary.fg.default,
+            color = SatsTheme.colors2.backgrounds2.secondary.default.fg,
             style = SatsTheme.typography.normal.small,
         )
 
@@ -139,7 +139,7 @@ private fun WorkoutInfo(
         if (subtitle != null) {
             MaterialText(
                 subtitle,
-                color = SatsTheme.colors2.backgrounds.secondary.fg.default,
+                color = SatsTheme.colors2.backgrounds2.secondary.default.fg,
                 style = SatsTheme.typography.normal.small,
             )
         }
@@ -151,9 +151,18 @@ private fun WorkoutInfo(
 @Composable
 private fun SatsCompletedWorkoutListItemPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsCompletedWorkoutListItem(
-                icon = { SatsWorkoutTypeIcon(SatsWorkoutTypeIconType.OwnTraining, null, Modifier.size(34.dp)) },
+                icon = {
+                    SatsWorkoutTypeIcon(
+                        SatsWorkoutTypeIconType.OwnTraining,
+                        null,
+                        Modifier.size(34.dp),
+                    )
+                },
                 timestamp = "Jul 18, 2023, 06:18",
                 title = "Gym training (M3)",
                 location = "at Colosseum",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsDivider.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsDivider.kt
@@ -77,12 +77,15 @@ private fun SatsHorizontalDividerPreview() {
     SatsTheme {
         SatsSurface(
             Modifier.size(200.dp),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             Column(
                 modifier = Modifier.padding(vertical = SatsTheme.spacing.m),
-                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m, Alignment.CenterVertically),
+                verticalArrangement = Arrangement.spacedBy(
+                    SatsTheme.spacing.m,
+                    Alignment.CenterVertically,
+                ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 SatsHorizontalDivider()
@@ -99,12 +102,15 @@ private fun SatsVerticalDividerPreview() {
     SatsTheme {
         SatsSurface(
             Modifier.size(200.dp),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = SatsTheme.spacing.m),
-                horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m, Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(
+                    SatsTheme.spacing.m,
+                    Alignment.CenterHorizontally,
+                ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 SatsVerticalDivider()

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsEmptyState.kt
@@ -74,7 +74,7 @@ fun SatsEmptyState(
             painter = icon,
             contentDescription = null,
             modifier = Modifier.size(36.dp),
-            tint = SatsTheme.colors2.surfaces.primary.fg.alternate,
+            tint = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
         )
 
         Column(
@@ -86,7 +86,7 @@ fun SatsEmptyState(
             if (body != null) {
                 MaterialText(
                     text = body,
-                    color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+                    color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
                     textAlign = TextAlign.Center,
                     style = SatsTheme.typography.normal.small,
                 )
@@ -111,7 +111,10 @@ data class SatsEmptyStateAction(val action: () -> Unit, val label: String)
 @Composable
 private fun SatsEmptyStateM3Preview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsEmptyState(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
@@ -128,7 +131,10 @@ private fun SatsEmptyStateM3Preview() {
 @Composable
 private fun SatsEmptyStateM2Preview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = false) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = false,
+        ) {
             SatsEmptyState(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",
@@ -145,7 +151,10 @@ private fun SatsEmptyStateM2Preview() {
 @Composable
 private fun SatsEmptyStateCardPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsEmptyStateCard(
                 icon = SatsTheme.icons.barbell,
                 title = "You don't have friends",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
@@ -98,8 +98,8 @@ fun SatsFancyTopAppBar(
     val expandPercent = scrollConnection?.expandPercent ?: 1f
 
     val contentColor = lerp(
-        start = SatsTheme.colors2.surfaces.primary.fg.default,
-        stop = SatsTheme.colors2.backgrounds.fixed.primary.fg.default,
+        start = SatsTheme.colors2.surfaces2.primary.default.fg,
+        stop = SatsTheme.colors2.backgrounds2.fixed.primary.default.fg,
         fraction = expandPercent,
     )
 
@@ -451,7 +451,7 @@ private const val AppBarExpandedAspectRatio = 1920f / 1080
 @Composable
 private fun SatsFancyTopAppBarExpandedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             val coroutineScope = rememberCoroutineScope()
             val scrollConnection = rememberSatsFancyTopAppBarNestedScrollConnection()
                 .also { coroutineScope.launch { it.expand(animate = false) } }
@@ -492,7 +492,7 @@ private fun SatsFancyTopAppBarExpandedPreview() {
 @Composable
 private fun SatsFancyTopAppBarCollapsedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             val coroutineScope = rememberCoroutineScope()
             val scrollConnection = rememberSatsFancyTopAppBarNestedScrollConnection()
                 .also { coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) { it.collapse(animate = false) } }
@@ -533,7 +533,7 @@ private fun SatsFancyTopAppBarCollapsedPreview() {
 @Composable
 private fun SatsFancyTopAppBarTestPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             val scrollConnection = rememberSatsFancyTopAppBarNestedScrollConnection()
 
             Column(Modifier.nestedScroll(scrollConnection)) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFormInputFields.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFormInputFields.kt
@@ -142,7 +142,7 @@ private fun DateTimeBox(
 ) {
     SatsSurface(
         modifier = modifier,
-        color = SatsTheme.colors2.surfaces.secondary.bg.default,
+        color = SatsTheme.colors2.surfaces2.secondary.default.bg,
         shape = SatsTheme.shapes.roundedCorners.extraSmall,
     ) {
         val color: Color = if (isEnabled) {
@@ -216,7 +216,7 @@ private fun LabelAndHint(label: String, hint: String?) {
             Text(
                 text = hint,
                 style = SatsTheme.typography.normal.small,
-                color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+                color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
             )
         }
     }
@@ -225,9 +225,9 @@ private fun LabelAndHint(label: String, hint: String?) {
 @Composable
 private fun valueTextStyle(isSingleLine: Boolean, isEnabled: Boolean): TextStyle {
     val color = if (isEnabled) {
-        SatsTheme.colors2.surfaces.primary.fg.alternate
+        SatsTheme.colors2.surfaces2.primary.default.fgAlternate
     } else {
-        SatsTheme.colors2.surfaces.primary.fg.disabled
+        SatsTheme.colors2.surfaces2.primary.default.fgDisabled
     }
 
     return SatsTheme.typography.normal.basic.copy(
@@ -243,7 +243,10 @@ private val MinSize = 48.dp
 @Composable
 private fun SatsFormTextFieldSingleLinePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsFormTextField(
                 textFieldState = rememberTextFieldState("Lorem ipsum"),
                 label = "Sample Text",
@@ -259,7 +262,10 @@ private fun SatsFormTextFieldSingleLinePreview() {
 @Composable
 private fun SatsFormTextFieldSingleLineDurationPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsFormTextField(
                 textFieldState = rememberTextFieldState("45"),
                 label = "Duration",
@@ -280,7 +286,10 @@ private fun SatsFormTextFieldSingleLineDurationPreview() {
 @Composable
 private fun SatsFormTextFieldMultiLinePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val text = buildString {
                 repeat(10) {
                     append("Lorem ipsum dolor sit amet. ")
@@ -291,7 +300,10 @@ private fun SatsFormTextFieldMultiLinePreview() {
                 textFieldState = rememberTextFieldState(text),
                 label = "Sample Text",
                 hint = "(optional)",
-                lineLimits = TextFieldLineLimits.MultiLine(minHeightInLines = 5, maxHeightInLines = 6),
+                lineLimits = TextFieldLineLimits.MultiLine(
+                    minHeightInLines = 5,
+                    maxHeightInLines = 6,
+                ),
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -302,7 +314,10 @@ private fun SatsFormTextFieldMultiLinePreview() {
 @Composable
 private fun SatsFormInputFieldPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             var value by remember { mutableStateOf(false) }
 
             SatsFormInputField(
@@ -322,7 +337,10 @@ private fun SatsFormInputFieldPreview() {
 @Composable
 private fun SatsFormDateTimeInputFieldPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val selectedDateTime by remember { mutableStateOf(LocalDateTime(2020, 1, 1, 12, 0)) }
 
             SatsFormDateTimeInputField(
@@ -330,8 +348,14 @@ private fun SatsFormDateTimeInputFieldPreview() {
                 value = selectedDateTime,
                 onDateClicked = { },
                 onTimeClicked = { },
-                formatDate = { DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(it.toJavaLocalDate()) },
-                formatTime = { DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(it.toJavaLocalTime()) },
+                formatDate = {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                        .format(it.toJavaLocalDate())
+                },
+                formatTime = {
+                    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+                        .format(it.toJavaLocalTime())
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGeneralListItem.kt
@@ -103,9 +103,9 @@ interface SatsGeneralListItemColors {
 object SatsGeneralListItemDefaults {
     @Composable
     fun generalListItemColors(
-        titleColor: Color = SatsTheme.colors2.surfaces.primary.fg.default,
-        subtitleColor: Color = SatsTheme.colors2.surfaces.primary.fg.alternate,
-        iconColor: Color = SatsTheme.colors2.surfaces.primary.fg.default,
+        titleColor: Color = SatsTheme.colors2.surfaces2.primary.default.fg,
+        subtitleColor: Color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
+        iconColor: Color = SatsTheme.colors2.surfaces2.primary.default.fg,
     ): SatsGeneralListItemColors = DefaultSatsGeneralListItem(
         titleColor = titleColor,
         subtitleColor = subtitleColor,
@@ -124,7 +124,7 @@ private class DefaultSatsGeneralListItem(
 @Composable
 private fun GeneralListItemPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -139,7 +139,7 @@ private fun GeneralListItemPreview() {
 @Composable
 private fun GeneralListItemWithSubtitlePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -155,7 +155,7 @@ private fun GeneralListItemWithSubtitlePreview() {
 @Composable
 private fun WithTrailingContentPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -171,7 +171,7 @@ private fun WithTrailingContentPreview() {
 @Composable
 private fun WithAdvancedTrailingContentPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -187,7 +187,7 @@ private fun WithAdvancedTrailingContentPreview() {
 @Composable
 private fun WithNonDefaultColorsPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -205,7 +205,7 @@ private fun WithNonDefaultColorsPreview() {
 @Composable
 private fun WithoutIconPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsGeneralListItem(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {},
@@ -221,9 +221,9 @@ private fun WithoutIconPreview() {
 @Composable
 private fun SatsGeneralListItemLoadingPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsTheme {
-                SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+                SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
                     SatsGeneralListItem(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = {},

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGxSessionImage.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsGxSessionImage.kt
@@ -30,7 +30,10 @@ fun SatsGxSessionImage(
 @Composable
 private fun SatsGxSessionImagePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsGxSessionImage(imageUrl = null, Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsJoinYourFriendsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsJoinYourFriendsCard.kt
@@ -35,9 +35,17 @@ fun SatsJoinYourFriendsCard(
 @Composable
 private fun SatsJoinYourFriendsCardPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsJoinYourFriendsCard(
-                pill = { SatsPill(label = "Susanne", image = { SatsProfileAvatarImage(imageUrl = null) }) },
+                pill = {
+                    SatsPill(
+                        label = "Susanne",
+                        image = { SatsProfileAvatarImage(imageUrl = null) },
+                    )
+                },
                 imageUrl = null,
                 title = "Indoor Running",
                 subtitle = "Today – 20:30",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsOutlinedTextField.kt
@@ -150,7 +150,7 @@ object SatsOutlinedTextFieldDefaults {
 @Composable
 private fun SatsOutlinedTextFieldEnabledPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsOutlinedTextField(
                 value = "Text",
                 onValueChange = { },
@@ -165,7 +165,7 @@ private fun SatsOutlinedTextFieldEnabledPreview() {
 @Composable
 private fun SatsOutlinedTextFieldDisabledPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsOutlinedTextField(
                 value = "Text",
                 onValueChange = { },

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPill.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPill.kt
@@ -23,7 +23,7 @@ fun SatsPill(
 ) {
     SatsSurface(
         modifier = modifier,
-        color = SatsTheme.colors2.surfaces.primary.bg.default,
+        color = SatsTheme.colors2.surfaces2.primary.default.bg,
         shape = SatsTheme.shapes.circle,
         useMaterial3 = true,
     ) {
@@ -37,10 +37,13 @@ fun SatsPill(
             )
 
             Text(
-                modifier = Modifier.padding(start = SatsTheme.spacing.xs, end = SatsTheme.spacing.s),
+                modifier = Modifier.padding(
+                    start = SatsTheme.spacing.xs,
+                    end = SatsTheme.spacing.s,
+                ),
                 text = label,
                 style = SatsTheme.typography.normal.small,
-                color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+                color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
             )
@@ -52,7 +55,10 @@ fun SatsPill(
 @Composable
 private fun SatsPillPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsPill(
                 label = "Susanne",
                 image = { SatsProfileAvatarImage(imageUrl = null) },

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPlaceholders.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsPlaceholders.kt
@@ -99,7 +99,7 @@ private fun rememberTextSize(text: String, style: TextStyle): DpSize {
 @Composable
 private fun SatsPlaceholderBoxPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(Modifier.padding(SatsTheme.spacing.m), spacedBy(SatsTheme.spacing.m)) {
                 SatsPlaceholderBox(
                     Modifier
@@ -120,7 +120,7 @@ private fun SatsPlaceholderBoxPreview() {
 @Composable
 private fun PlaceholderTextPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(Modifier.padding(SatsTheme.spacing.m), spacedBy(SatsTheme.spacing.m)) {
                 SatsPlaceholderText("Some Heading", style = SatsTheme.typography.emphasis.headline2)
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsProfileAvatarImage.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsProfileAvatarImage.kt
@@ -42,7 +42,10 @@ fun SatsProfileAvatarImagePlaceholder(modifier: Modifier = Modifier) {
 @Composable
 private fun SatsProfileAvatarImagePreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsProfileAvatarImage(
                 imageUrl = null,
                 Modifier
@@ -57,7 +60,10 @@ private fun SatsProfileAvatarImagePreview() {
 @Composable
 private fun SatsProfileAvatarImagePlaceholderPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsProfileAvatarImagePlaceholder(
                 Modifier
                     .padding(SatsTheme.spacing.m)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
@@ -29,7 +29,10 @@ private val colors
 @Composable
 private fun EnabledSelectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsRadioButton(selected = true, onClick = {})
         }
     }
@@ -39,7 +42,10 @@ private fun EnabledSelectedPreview() {
 @Composable
 private fun EnabledUnselectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsRadioButton(selected = false, onClick = {})
         }
     }
@@ -49,7 +55,10 @@ private fun EnabledUnselectedPreview() {
 @Composable
 private fun DisabledSelectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsRadioButton(selected = true, onClick = {}, enabled = false)
         }
     }
@@ -59,7 +68,10 @@ private fun DisabledSelectedPreview() {
 @Composable
 private fun DisabledUnselectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsRadioButton(selected = false, onClick = {}, enabled = false)
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsScaleBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsScaleBar.kt
@@ -37,7 +37,7 @@ fun SatsScaleBar(
                 Box(
                     Modifier
                         .weight(1f)
-                        .background(SatsTheme.colors2.graphicalElements.progressBar.indicator)
+                        .background(SatsTheme.colors2.graphicalElements.progressBar2.default.fg)
                         .fillMaxHeight(),
                 )
             }
@@ -46,7 +46,7 @@ fun SatsScaleBar(
                 Box(
                     Modifier
                         .weight(1f)
-                        .background(SatsTheme.colors2.graphicalElements.progressBar.bg)
+                        .background(SatsTheme.colors2.graphicalElements.progressBar2.default.bg)
                         .fillMaxHeight(),
                 )
             }
@@ -59,7 +59,7 @@ fun SatsScaleBar(
 @Composable
 private fun SatsScaleBarPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsScaleBar(
                 label = "Choreography",
                 difficultyLevel = 3,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSearchBar.kt
@@ -51,7 +51,7 @@ fun SatsSearchBar(
                 innerTextField = innerTextField,
                 placeholder = {
                     if (placeholder != null) {
-                        Text(placeholder, color = SatsTheme.colors2.surfaces.primary.fg.alternate)
+                        Text(placeholder, color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate)
                     }
                 },
                 modifier = Modifier,
@@ -66,7 +66,7 @@ fun SatsSearchBar(
                         Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
                             Icon(
                                 icon = SatsTheme.icons.search,
-                                tint = SatsTheme.colors2.surfaces.primary.fg.default,
+                                tint = SatsTheme.colors2.surfaces2.primary.default.fg,
                             )
                         }
                     }
@@ -86,13 +86,13 @@ fun SatsSearchBar(
             )
         },
         singleLine = true,
-        textStyle = SatsTheme.typography.normal.basic.copy(color = SatsTheme.colors2.backgrounds.primary.fg.default),
+        textStyle = SatsTheme.typography.normal.basic.copy(color = SatsTheme.colors2.backgrounds2.primary.default.fg),
         keyboardOptions = KeyboardOptions(
             capitalization = KeyboardCapitalization.Sentences,
             imeAction = ImeAction.Done,
         ),
         keyboardActions = keyboardActions,
-        cursorBrush = SolidColor(SatsTheme.colors2.backgrounds.primary.fg.default),
+        cursorBrush = SolidColor(SatsTheme.colors2.backgrounds2.primary.default.fg),
     )
 }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSurface.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.Surface as Material3Surface
 @Composable
 fun SatsSurface(
     modifier: Modifier = Modifier,
-    color: Color = SatsTheme.colors2.surfaces.primary.bg.default,
+    color: Color = SatsTheme.colors2.surfaces2.primary.default.bg,
     contentColor: Color = satsContentColor2For(color),
     shape: Shape = RectangleShape,
     border: BorderStroke? = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSwitch.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsSwitch.kt
@@ -55,7 +55,10 @@ private val colors
 @Composable
 private fun EnabledSelectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsSwitch(checked = true, onCheckedChange = {}, Modifier.padding(SatsTheme.spacing.m))
         }
     }
@@ -65,7 +68,10 @@ private fun EnabledSelectedPreview() {
 @Composable
 private fun EnabledUnselectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsSwitch(checked = false, onCheckedChange = {}, Modifier.padding(SatsTheme.spacing.m))
         }
     }
@@ -75,8 +81,16 @@ private fun EnabledUnselectedPreview() {
 @Composable
 private fun DisabledSelectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsSwitch(checked = true, onCheckedChange = {}, Modifier.padding(SatsTheme.spacing.m), enabled = false)
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsSwitch(
+                checked = true,
+                onCheckedChange = {},
+                Modifier.padding(SatsTheme.spacing.m),
+                enabled = false,
+            )
         }
     }
 }
@@ -85,8 +99,16 @@ private fun DisabledSelectedPreview() {
 @Composable
 private fun DisabledUnselectedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsSwitch(checked = false, onCheckedChange = {}, Modifier.padding(SatsTheme.spacing.m), enabled = false)
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsSwitch(
+                checked = false,
+                onCheckedChange = {},
+                Modifier.padding(SatsTheme.spacing.m),
+                enabled = false,
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTag.kt
@@ -46,6 +46,7 @@ fun SatsTag(
             topStart = CornerSize(0.dp),
             bottomStart = CornerSize(0.dp),
         )
+
         SatsTagShape.Right -> SatsTheme.shapes.roundedCorners.extraSmall.copy(
             topEnd = CornerSize(0.dp),
             bottomEnd = CornerSize(0.dp),
@@ -210,7 +211,7 @@ private fun SatsTagLayout(
 @Composable
 private fun SmallSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -228,7 +229,7 @@ private fun SmallSatsTagPreview() {
 @Composable
 private fun BasicSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -246,7 +247,7 @@ private fun BasicSatsTagPreview() {
 @Composable
 private fun SmallLeftAlignedSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -264,7 +265,7 @@ private fun SmallLeftAlignedSatsTagPreview() {
 @Composable
 private fun BasicLeftAlignedSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -282,7 +283,7 @@ private fun BasicLeftAlignedSatsTagPreview() {
 @Composable
 private fun SmallRightAlignedSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -300,7 +301,7 @@ private fun SmallRightAlignedSatsTagPreview() {
 @Composable
 private fun BasicRightAlignedSatsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -318,7 +319,7 @@ private fun BasicRightAlignedSatsTagPreview() {
 @Composable
 private fun SatsRewardsTagPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
@@ -336,7 +337,7 @@ private fun SatsRewardsTagPreview() {
 @Composable
 private fun SatsTagPlaceholderPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsTagPlaceholder("Tag Text", Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTextField.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTextField.kt
@@ -53,7 +53,7 @@ fun SatsTextField(
 @Composable
 private fun SatsTextFieldEnabledPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsTextField(
                 value = "Text",
                 onValueChange = { },
@@ -68,7 +68,7 @@ private fun SatsTextFieldEnabledPreview() {
 @Composable
 private fun SatsTextFieldDisabledPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
             SatsTextField(
                 value = "Text",
                 onValueChange = { },

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledCard.kt
@@ -87,7 +87,10 @@ private val CardHeaderHeight = 48.dp
 @Composable
 private fun SatsTitledCardWithoutActionPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTitledCard(
                 title = "Lorem ipsum",
                 modifier = Modifier.padding(SatsTheme.spacing.m),
@@ -105,7 +108,10 @@ private fun SatsTitledCardWithoutActionPreview() {
 @Composable
 private fun SatsTitledCardWithChevronActionPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTitledCard(
                 title = "Lorem ipsum",
                 action = SatsTitledCardAction.Chevron(action = {}, contentDescription = null),

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledSection.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTitledSection.kt
@@ -89,7 +89,7 @@ private fun SatsTitledSectionPreview() {
     SatsTheme {
         SatsSurface(
             modifier = Modifier.fillMaxWidth(),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             SatsTitledSection("Section Title") { contentPadding ->
@@ -111,7 +111,7 @@ private fun SatsTitledSectionWithChevronActionPreview() {
     SatsTheme {
         SatsSurface(
             modifier = Modifier.fillMaxWidth(),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             SatsTitledSection(
@@ -143,7 +143,7 @@ private fun SatsTitledSectionScrollableRowPreview() {
     SatsTheme {
         SatsSurface(
             modifier = Modifier.fillMaxWidth(),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             SatsTitledSection("Section Title") { contentPadding ->

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTrafficLight.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsTrafficLight.kt
@@ -60,7 +60,10 @@ enum class TrafficLightColor {
 @Composable
 private fun SatsTrafficLightPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             Column(
                 Modifier.padding(SatsTheme.spacing.m),
                 Arrangement.spacedBy(SatsTheme.spacing.m),

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsYourMostBookedCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsYourMostBookedCard.kt
@@ -28,7 +28,10 @@ fun SatsYourMostBookedCard(
 @Composable
 private fun SatsYourMostBookedCardPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsYourMostBookedCard(
                 imageUrl = null,
                 title = "Indoor Running",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsLargeTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsLargeTopAppBar.kt
@@ -47,7 +47,7 @@ fun SatsLargeTopAppBar(
 ) {
     LargeTopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = SatsTheme.colors2.backgrounds.primary.bg.default,
+            containerColor = SatsTheme.colors2.backgrounds2.primary.default.bg,
             scrolledContainerColor = SatsTopAppBarDefaults.containerColor,
         ),
         title = title,
@@ -64,11 +64,20 @@ fun SatsLargeTopAppBar(
 @Composable
 private fun SatsLargeTopAppBarPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsLargeTopAppBar(
                 title = "Top App Bar",
                 scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
-                navigationIcon = { SatsTopAppBarIconButton(onClick = {}, SatsTheme.icons.back, onClickLabel = null) },
+                navigationIcon = {
+                    SatsTopAppBarIconButton(
+                        onClick = {},
+                        SatsTheme.icons.back,
+                        onClickLabel = null,
+                    )
+                },
                 actions = {
                     listOf(SatsTheme.icons.barbell, SatsTheme.icons.addPerson).forEach { icon ->
                         SatsTopAppBarIconButton(onClick = {}, icon, onClickLabel = null)

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/appbar/SatsTopAppBar.kt
@@ -55,7 +55,7 @@ fun SatsTopAppBar(
     val containerColor = if (scrollBehavior == null) {
         SatsTopAppBarDefaults.containerColor
     } else {
-        SatsTheme.colors2.backgrounds.primary.bg.default
+        SatsTheme.colors2.backgrounds2.primary.default.bg
     }
 
     TopAppBar(
@@ -84,13 +84,13 @@ fun SatsTopAppBar(
 object SatsTopAppBarDefaults {
     val containerColor
         @Composable get() = if (SatsTheme.colors2.isLightMode) {
-            SatsTheme.colors2.surfaces.fixed.primary.bg.default.copy(alpha = .05f)
+            SatsTheme.colors2.surfaces2.fixed.primary.default.bg.copy(alpha = .05f)
         } else {
-            SatsTheme.colors2.surfaces.primary.bg.default
-        }.compositeOver(SatsTheme.colors2.backgrounds.primary.bg.default)
+            SatsTheme.colors2.surfaces2.primary.default.bg
+        }.compositeOver(SatsTheme.colors2.backgrounds2.primary.default.bg)
 
     val contentColor
-        @Composable get() = SatsTheme.colors2.surfaces.primary.fg.default
+        @Composable get() = SatsTheme.colors2.surfaces2.primary.default.fg
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -98,10 +98,19 @@ object SatsTopAppBarDefaults {
 @Composable
 private fun SatsTopAppBarPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTopAppBar(
                 modifier = Modifier.padding(SatsTheme.spacing.m),
-                navigationIcon = { SatsTopAppBarIconButton(onClick = {}, SatsTheme.icons.back, onClickLabel = null) },
+                navigationIcon = {
+                    SatsTopAppBarIconButton(
+                        onClick = {},
+                        SatsTheme.icons.back,
+                        onClickLabel = null,
+                    )
+                },
                 title = "Top App Bar",
                 actions = {
                     listOf(SatsTheme.icons.barbell, SatsTheme.icons.addPerson).forEach { icon ->

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsButton.kt
@@ -120,7 +120,10 @@ fun SatsButton(
 @Composable
 private fun SatsButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 SatsButton(onClick = {}, color.name, Modifier.padding(SatsTheme.spacing.s), color)
                 SatsButton(
@@ -141,7 +144,7 @@ private fun SatsButtonFontScalePreview() {
     SatsTheme {
         SatsSurface(
             modifier = Modifier.fillMaxWidth(),
-            color = SatsTheme.colors2.backgrounds.primary.bg.default,
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
             useMaterial3 = true,
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/button/SatsIconButton.kt
@@ -230,7 +230,10 @@ private fun SatsTopAppBarIconButton(
 @Composable
 private fun SatsIconButtonPreview(@PreviewParameter(SatsButtonColorProvider::class) color: SatsButtonColor) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsIconButton(
                 onClick = {},
                 icon = SatsTheme.icons.barbell,
@@ -246,7 +249,10 @@ private fun SatsIconButtonPreview(@PreviewParameter(SatsButtonColorProvider::cla
 @Composable
 private fun SatsTopAppBarIconButtonPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsTopAppBarIconButton(
                 onClick = {},
                 icon = SatsTheme.icons.back,
@@ -261,7 +267,10 @@ private fun SatsTopAppBarIconButtonPreview() {
 @Composable
 private fun SatsBellIconButtonNoCherryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBellIconButton(
                 onClick = {},
                 onClickLabel = null,
@@ -276,7 +285,10 @@ private fun SatsBellIconButtonNoCherryPreview() {
 @Composable
 private fun SatsBellIconButtonWithCherryPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsBellIconButton(
                 onClick = {},
                 onClickLabel = null,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsCard.kt
@@ -26,7 +26,7 @@ fun SatsCard(
 ) {
     SatsSurface(
         modifier = modifier,
-        color = SatsTheme.colors2.surfaces.primary.bg.default,
+        color = SatsTheme.colors2.surfaces2.primary.default.bg,
         shape = SatsTheme.shapes.roundedCorners.small,
         elevation = 1.dp,
         content = content,
@@ -38,7 +38,7 @@ fun SatsCard(
 private fun Material3Preview() {
     SatsTheme {
         CompositionLocalProvider(LocalUseMaterial3 provides true) {
-            SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+            SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
                 SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
                     Column {
                         Image(
@@ -72,7 +72,7 @@ private fun Material3Preview() {
 private fun Material2Preview() {
     SatsTheme {
         CompositionLocalProvider(LocalUseMaterial3 provides false) {
-            SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default) {
+            SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg) {
                 SatsCard(Modifier.padding(SatsTheme.spacing.m)) {
                     Column {
                         Image(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/chip/SatsChip.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/chip/SatsChip.kt
@@ -1,4 +1,3 @@
-
 package com.sats.dna.components.chip
 
 import androidx.compose.foundation.layout.padding
@@ -34,7 +33,10 @@ fun SatsChip(label: String, modifier: Modifier = Modifier) {
 @Composable
 private fun SatsChipPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsChip("Chip Text", Modifier.padding(SatsTheme.spacing.m))
         }
     }
@@ -44,7 +46,10 @@ private fun SatsChipPreview() {
 @Composable
 private fun SatsChipTruncatedPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsChip(
                 "A very long chip text",
                 Modifier

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/icons/SatsDefaultInstructorIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/icons/SatsDefaultInstructorIcon.kt
@@ -58,8 +58,14 @@ enum class SatsDefaultInstructorIconType {
 @Composable
 private fun SatsDefaultInstructorIconGxPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsDefaultInstructorIcon(SatsDefaultInstructorIconType.Gx, Modifier.padding(SatsTheme.spacing.m))
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsDefaultInstructorIcon(
+                SatsDefaultInstructorIconType.Gx,
+                Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }
@@ -68,8 +74,14 @@ private fun SatsDefaultInstructorIconGxPreview() {
 @Composable
 private fun SatsDefaultInstructorIconPtPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsDefaultInstructorIcon(SatsDefaultInstructorIconType.Pt, Modifier.padding(SatsTheme.spacing.m))
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsDefaultInstructorIcon(
+                SatsDefaultInstructorIconType.Pt,
+                Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/icons/SatsWorkoutTypeIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/icons/SatsWorkoutTypeIcon.kt
@@ -69,8 +69,15 @@ private fun SatsWorkoutTypeIconPreview(
     @PreviewParameter(WorkoutTypePreviewProvider::class) workoutType: SatsWorkoutTypeIconType,
 ) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            SatsWorkoutTypeIcon(workoutType, contentDescription = null, Modifier.padding(SatsTheme.spacing.m))
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            SatsWorkoutTypeIcon(
+                workoutType,
+                contentDescription = null,
+                Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/internal/GxSessionCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/internal/GxSessionCard.kt
@@ -66,7 +66,10 @@ internal fun GxSessionCard(
 @Composable
 private fun GxSessionCardPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             GxSessionCard(
                 imageUrl = null,
                 title = "Indoor Running",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsCircularSteppedProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsCircularSteppedProgressIndicator.kt
@@ -135,7 +135,7 @@ private fun CompletedCheckMark(modifier: Modifier = Modifier) {
         modifier
             .clip(SatsTheme.shapes.circle)
             .aspectRatio(1f)
-            .background(SatsTheme.colors2.graphicalElements.progressBar.indicator),
+            .background(SatsTheme.colors2.graphicalElements.progressBar2.default.fg),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
@@ -153,7 +153,7 @@ private fun CompletedCheckMark(modifier: Modifier = Modifier) {
 @Composable
 private fun SatsCircularSteppingProgressIndicatorPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(color = SatsTheme.colors2.backgrounds2.primary.default.bg, useMaterial3 = true) {
             SatsCircularSteppedProgressIndicator(
                 progress = SteppingProgress(
                     groups = listOf(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressBar.kt
@@ -23,8 +23,8 @@ fun SatsLinearProgressBar(
     progress: Float,
     modifier: Modifier = Modifier,
 ) {
-    val foregroundColor = SatsTheme.colors2.graphicalElements.progressBar.indicator
-    val backgroundColor = SatsTheme.colors2.graphicalElements.progressBar.bg
+    val foregroundColor = SatsTheme.colors2.graphicalElements.progressBar2.default.fg
+    val backgroundColor = SatsTheme.colors2.graphicalElements.progressBar2.default.bg
 
     Canvas(
         modifier

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBar.kt
@@ -160,7 +160,10 @@ private fun ActionButton(action: SatsProteinBarAction, modifier: Modifier = Modi
 @Composable
 private fun SatsProteinBarPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val message = "Something went wrong. You should probably try that one more time."
             val action = SatsProteinBarAction(action = {}, "Try again")
 
@@ -173,7 +176,10 @@ private fun SatsProteinBarPreview() {
 @Composable
 private fun SatsProteinBarInfoPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "This is the title of the Protein Bar",
                 message = "This text exists so that you can read it. Did you read it through all the way?",
@@ -191,7 +197,10 @@ private fun SatsProteinBarInfoPreview() {
 @Composable
 private fun SatsProteinBarSuccessPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "Yay! Invitations have been sent!",
                 message = "You can always add or remove friends later, or change other details.",
@@ -209,7 +218,10 @@ private fun SatsProteinBarSuccessPreview() {
 @Composable
 private fun SatsProteinBarWarningPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "This is the title of the Protein Bar",
                 message = "This text exists so that you can read it. Did you read it through all the way?",
@@ -227,7 +239,10 @@ private fun SatsProteinBarWarningPreview() {
 @Composable
 private fun SatsProteinBarErrorPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "Oh no, that's not great!",
                 message = "It looks like whatever you were trying to do didn't happen according to plan. You may " +
@@ -246,7 +261,10 @@ private fun SatsProteinBarErrorPreview() {
 @Composable
 private fun SatsProteinBarWithActionPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "Yay! Invitations have been sent!",
                 message = "You can always add or remove friends later, or change other details.",
@@ -264,7 +282,10 @@ private fun SatsProteinBarWithActionPreview() {
 @Composable
 private fun SatsProteinBarWithDismissAndActionPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "Yay! Invitations have been sent!",
                 message = "You can always add or remove friends later, or change other details.",
@@ -282,7 +303,10 @@ private fun SatsProteinBarWithDismissAndActionPreview() {
 @Composable
 private fun SatsProteinBarFontSizesPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             val visuals = SatsProteinBarDefaults.visuals(
                 title = "Yay! Invitations have been sent!",
                 message = "You can always add or remove friends later, or change other details.",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBarVisuals.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/proteinbar/SatsProteinBarVisuals.kt
@@ -76,33 +76,33 @@ object SatsProteinBarDefaults {
     @Composable
     private fun SatsProteinBarTheme.proteinBarColors(): SatsProteinBarColors = when (this) {
         SatsProteinBarTheme.Neutral -> SatsProteinBarColors(
-            containerColor = SatsTheme.colors2.surfaces.primary.bg.default,
-            contentColor = SatsTheme.colors2.surfaces.primary.fg.default,
-            titleColor = SatsTheme.colors2.surfaces.primary.fg.alternate,
+            containerColor = SatsTheme.colors2.surfaces2.primary.default.bg,
+            contentColor = SatsTheme.colors2.surfaces2.primary.default.fg,
+            titleColor = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
         )
 
         SatsProteinBarTheme.Info -> SatsProteinBarColors(
-            containerColor = SatsTheme.colors2.signalSurfaces.information.bg,
-            contentColor = SatsTheme.colors2.signalSurfaces.information.fg.default,
-            titleColor = SatsTheme.colors2.signalSurfaces.information.fg.alternate,
+            containerColor = SatsTheme.colors2.signalSurfaces2.information.default.bg,
+            contentColor = SatsTheme.colors2.signalSurfaces2.information.default.fg,
+            titleColor = SatsTheme.colors2.signalSurfaces2.information.alternate.fg,
         )
 
         SatsProteinBarTheme.Success -> SatsProteinBarColors(
-            containerColor = SatsTheme.colors2.signalSurfaces.success.bg,
-            contentColor = SatsTheme.colors2.signalSurfaces.success.fg.default,
-            titleColor = SatsTheme.colors2.signalSurfaces.success.fg.alternate,
+            containerColor = SatsTheme.colors2.signalSurfaces2.success.default.bg,
+            contentColor = SatsTheme.colors2.signalSurfaces2.success.default.fg,
+            titleColor = SatsTheme.colors2.signalSurfaces2.success.alternate.fg,
         )
 
         SatsProteinBarTheme.Warning -> SatsProteinBarColors(
-            containerColor = SatsTheme.colors2.signalSurfaces.warning.bg,
-            contentColor = SatsTheme.colors2.signalSurfaces.warning.fg.default,
-            titleColor = SatsTheme.colors2.signalSurfaces.warning.fg.alternate,
+            containerColor = SatsTheme.colors2.signalSurfaces2.warning.default.bg,
+            contentColor = SatsTheme.colors2.signalSurfaces2.warning.default.fg,
+            titleColor = SatsTheme.colors2.signalSurfaces2.warning.alternate.fg,
         )
 
         SatsProteinBarTheme.Error -> SatsProteinBarColors(
-            containerColor = SatsTheme.colors2.signalSurfaces.error.bg,
-            contentColor = SatsTheme.colors2.signalSurfaces.error.fg.default,
-            titleColor = SatsTheme.colors2.signalSurfaces.error.fg.alternate,
+            containerColor = SatsTheme.colors2.signalSurfaces2.error.default.bg,
+            contentColor = SatsTheme.colors2.signalSurfaces2.error.default.fg,
+            titleColor = SatsTheme.colors2.signalSurfaces2.error.alternate.fg,
         )
     }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/screen/SatsScreen.kt
@@ -45,9 +45,14 @@ fun SatsScreen(
             modifier = modifier,
             topBar = topBar,
             bottomBar = bottomBar,
-            containerColor = SatsTheme.colors2.backgrounds.primary.bg.default,
-            contentColor = SatsTheme.colors2.backgrounds.primary.fg.default,
-            snackbarHost = { SatsProteinBarHost(proteinBarHostState, Modifier.padding(proteinBarPadding)) },
+            containerColor = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            contentColor = SatsTheme.colors2.backgrounds2.primary.default.fg,
+            snackbarHost = {
+                SatsProteinBarHost(
+                    proteinBarHostState,
+                    Modifier.padding(proteinBarPadding),
+                )
+            },
             floatingActionButton = floatingActionButton,
         ) { scaffoldContentPadding ->
             val screenContentPadding = PaddingValues(

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SatsFriendsBookingStatusListItem.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SatsFriendsBookingStatusListItem.kt
@@ -57,11 +57,25 @@ fun SatsFriendsBookingStatusListItem(
 
         Spacer(Modifier.weight(1f))
         val textColor = when (bookingState.status) {
-            FriendsBookingStatus.Owner -> SatsTheme.colors.primary.default
-            FriendsBookingStatus.Invited, FriendsBookingStatus.Booked -> SatsTheme.colors2.surfaces.primary.fg.success
-            FriendsBookingStatus.Pending -> SatsTheme.colors2.surfaces.primary.fg.warning
-            FriendsBookingStatus.Declined, FriendsBookingStatus.Removed -> SatsTheme.colors2.surfaces.primary.fg.error
-            FriendsBookingStatus.WaitingList -> SatsTheme.colors2.surfaces.primary.fg.waitlist
+            FriendsBookingStatus.Owner -> {
+                SatsTheme.colors.primary.default
+            }
+
+            FriendsBookingStatus.Invited, FriendsBookingStatus.Booked -> {
+                SatsTheme.colors2.surfaces2.primary.default.fgSuccess
+            }
+
+            FriendsBookingStatus.Pending -> {
+                SatsTheme.colors2.surfaces2.primary.default.fgWarning
+            }
+
+            FriendsBookingStatus.Declined, FriendsBookingStatus.Removed -> {
+                SatsTheme.colors2.surfaces2.primary.default.fgError
+            }
+
+            FriendsBookingStatus.WaitingList -> {
+                SatsTheme.colors2.surfaces2.primary.default.fgWaitingList
+            }
         }
         Text(bookingState.statusText, color = textColor)
         if (contextMenu != null) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SatsSessionDetailsInfoSection.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/sessiondetails/SatsSessionDetailsInfoSection.kt
@@ -99,7 +99,7 @@ fun SatsSessionDetailsInfoLabel(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val contentColor = if (onClick == null) {
-            SatsTheme.colors2.backgrounds.primary.fg.default
+            SatsTheme.colors2.backgrounds2.primary.default.fg
         } else {
             SatsTheme.colors2.buttons.action.default.fg
         }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/SatsSchedule.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/SatsSchedule.kt
@@ -102,7 +102,7 @@ private fun ScheduledDays(
                 MaterialText(
                     text = dayName,
                     modifier = Modifier.padding(horizontal = cardInnerPadding),
-                    color = SatsTheme.colors2.surfaces.primary.fg.alternate,
+                    color = SatsTheme.colors2.surfaces2.primary.default.fgAlternate,
                     style = SatsTheme.typography.normal.small,
                 )
 
@@ -199,7 +199,10 @@ private fun SatsSchedulePreview() {
     )
 
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsSchedule(schedule, onWorkoutClicked = {}, Modifier.padding(SatsTheme.spacing.m))
         }
     }
@@ -248,7 +251,10 @@ private fun SatsScheduleWithCardButtonPreview() {
     )
 
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsSchedule(
                 workouts = schedule,
                 onWorkoutClicked = {},
@@ -272,7 +278,10 @@ private fun SatsScheduleWithCardButtonPreview() {
 @Composable
 private fun SatsSchedulePlaceholderPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             SatsSchedulePlaceholder(Modifier.padding(SatsTheme.spacing.m))
         }
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/SatsWorkoutTypeColorIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/upcomingworkouts/SatsWorkoutTypeColorIndicator.kt
@@ -52,7 +52,7 @@ internal fun TimeAndDuration(
         MaterialText(
             text = duration,
             style = SatsTheme.typography.normal.small,
-            color = SatsTheme.colors2.backgrounds.primary.fg.alternate,
+            color = SatsTheme.colors2.backgrounds2.primary.default.fgAlternate,
         )
     }
 }
@@ -76,7 +76,7 @@ internal fun WorkoutInfo(
             MaterialText(
                 text = location,
                 style = SatsTheme.typography.normal.small,
-                color = SatsTheme.colors2.backgrounds.primary.fg.alternate,
+                color = SatsTheme.colors2.backgrounds2.primary.default.fgAlternate,
             )
         }
 
@@ -84,7 +84,7 @@ internal fun WorkoutInfo(
             MaterialText(
                 text = instructor,
                 style = SatsTheme.typography.normal.small,
-                color = SatsTheme.colors2.backgrounds.primary.fg.alternate,
+                color = SatsTheme.colors2.backgrounds2.primary.default.fgAlternate,
             )
         }
 
@@ -92,7 +92,7 @@ internal fun WorkoutInfo(
             MaterialText(
                 text = workoutType,
                 style = SatsTheme.typography.normal.small,
-                color = SatsTheme.colors2.backgrounds.primary.fg.alternate,
+                color = SatsTheme.colors2.backgrounds2.primary.default.fgAlternate,
             )
         }
 
@@ -105,8 +105,8 @@ internal fun WorkoutInfo(
 @Composable
 private fun WaitingListStatus(status: SatsWaitingListStatus) {
     val color = when (status) {
-        is SatsWaitingListStatus.OnWaitingList -> SatsTheme.colors2.surfaces.primary.fg.waitlist
-        is SatsWaitingListStatus.SpotSecured -> SatsTheme.colors2.surfaces.primary.fg.success
+        is SatsWaitingListStatus.OnWaitingList -> SatsTheme.colors2.surfaces2.primary.default.fgWaitingList
+        is SatsWaitingListStatus.SpotSecured -> SatsTheme.colors2.surfaces2.primary.default.fgSuccess
     }
 
     MaterialText(
@@ -119,7 +119,7 @@ private fun WaitingListStatus(status: SatsWaitingListStatus) {
         status.waitingListText?.let {
             MaterialText(
                 text = status.waitingListText,
-                color = SatsTheme.colors2.surfaces.primary.fg.waitlist,
+                color = SatsTheme.colors2.surfaces2.primary.default.fgWaitingList,
                 style = SatsTheme.typography.normal.small,
             )
         }
@@ -130,7 +130,10 @@ private fun WaitingListStatus(status: SatsWaitingListStatus) {
 @Composable
 private fun TimeAndDurationPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             TimeAndDuration(
                 time = "9:00 PM",
                 duration = "45 min",
@@ -144,7 +147,10 @@ private fun TimeAndDurationPreview() {
 @Composable
 private fun WorkoutInfoPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             WorkoutInfo(
                 name = "Yoga Flow",
                 location = "SATS Nydalen",
@@ -161,7 +167,10 @@ private fun WorkoutInfoPreview() {
 @Composable
 private fun WorkoutInfoOnWaitingListPreview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             WorkoutInfo(
                 name = "Yoga Flow",
                 location = "SATS Nydalen",

--- a/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/internal/MaterialIcon.kt
@@ -42,8 +42,15 @@ internal fun materialIconTint(): Color {
 @Composable
 private fun MaterialIconM2Preview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = false) {
-            MaterialIcon(SatsTheme.icons.barbell, contentDescription = null, Modifier.padding(SatsTheme.spacing.m))
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = false,
+        ) {
+            MaterialIcon(
+                SatsTheme.icons.barbell,
+                contentDescription = null,
+                Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }
@@ -52,8 +59,15 @@ private fun MaterialIconM2Preview() {
 @Composable
 private fun MaterialIconM3Preview() {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
-            MaterialIcon(SatsTheme.icons.barbell, contentDescription = null, Modifier.padding(SatsTheme.spacing.m))
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
+            MaterialIcon(
+                SatsTheme.icons.barbell,
+                contentDescription = null,
+                Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/shapes/SatsShapes.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/shapes/SatsShapes.kt
@@ -62,13 +62,16 @@ object SatsShapes {
 @Composable
 private fun Preview(@PreviewParameter(SatsShapePreviewProvider::class) shape: Shape) {
     SatsTheme {
-        SatsSurface(color = SatsTheme.colors2.backgrounds.primary.bg.default, useMaterial3 = true) {
+        SatsSurface(
+            color = SatsTheme.colors2.backgrounds2.primary.default.bg,
+            useMaterial3 = true,
+        ) {
             Box(
                 Modifier
                     .size(256.dp)
                     .padding(SatsTheme.spacing.m)
                     .clip(shape)
-                    .background(SatsTheme.colors2.backgrounds.fixed.primary.bg.default),
+                    .background(SatsTheme.colors2.backgrounds2.fixed.primary.default.bg),
             )
         }
     }


### PR DESCRIPTION
Introduce a new `ColorSet` type that has a background and foreground color. The idea is that this essentially replaces the need for `contentColorFor`-style functions, replacing this:

```kotlin
@Composable
fun CardOrWhatever(
    containerColor: Color,
    contentColor: Color = satsContentColor2For(containerColor),
) {
    Box(Modifier.background(containerColor)) {
        Text("Some text", color = contentColor)
    }
}
```

with this:

```kotlin
@Composable
fun CardOrWhatever(colorSet: ColorSet) {
    Box(Modifier.background(colorSet.bg)) {
        Text("Some text", color = colorSet.fg)
    }
}
```

This PR should be completely backwards-compatible, with deprecations in some of the colors that couldn't be replaced that easily.