### PR TITLE
NMA-6500: Generate SatsIcons.kt from vector drawable files

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,4 +1,5 @@
 .env
+SatsIcons.kt
 android-vector-drawables/
 downloaded-figma-icons/
 node_modules/

--- a/scripts/generate-sats-icons-from-vector-drawables.js
+++ b/scripts/generate-sats-icons-from-vector-drawables.js
@@ -9,6 +9,7 @@ function generateSatsIconsObject(filenames) {
     const packageDeclaration = 'package com.sats.dna.icons\n\n';
 
     const importsDeclaration = [
+        'import androidx.compose.runtime.Composable',
         'import androidx.compose.ui.graphics.vector.ImageVector',
         'import androidx.compose.ui.res.vectorResource',
         'import com.sats.dna.R',

--- a/scripts/generate-sats-icons-from-vector-drawables.js
+++ b/scripts/generate-sats-icons-from-vector-drawables.js
@@ -1,0 +1,47 @@
+const fs = require('fs').promises;
+
+function readAndroidVectorDrawables() {
+    return fs.readdir('./android-vector-drawables')
+        .then(filenames => filenames.filter(filename => filename.match(/ic_.+\.xml/)));
+}
+
+function generateSatsIconsObject(filenames) {
+    const packageDeclaration = 'package com.sats.dna.icons\n\n';
+
+    const importsDeclaration = [
+        'import androidx.compose.ui.graphics.vector.ImageVector',
+        'import androidx.compose.ui.res.vectorResource',
+        'import com.sats.dna.R',
+    ].sort().join('\n') + '\n\n';
+
+    const propertiesDeclaration = filenames.map(filename => {
+        const propertyName = camelize(filename);
+        const resName = filename.replace(".xml", "");
+        const indent = '    '
+
+        return `${indent}val ${propertyName}: ImageVector\n` +
+            `${indent}${indent}@Composable get() = ImageVector.vectorResource(R.drawable.${resName})`;
+    }).join('\n\n')
+
+    return packageDeclaration +
+        importsDeclaration +
+        'object SatsIcons {\n' +
+        propertiesDeclaration +
+        '\n}';
+}
+
+function saveToFile(kotlinCode) {
+    return fs.writeFile('SatsIcons.kt', kotlinCode)
+}
+
+function camelize(str) {
+    return str
+        .replace("ic_", "")
+        .replace(".xml", "")
+        .replace(/_([a-z]+)/g, (_, match) => match[0].toUpperCase() + match.substring(1));
+}
+
+readAndroidVectorDrawables()
+    .then(generateSatsIconsObject)
+    .then(saveToFile)
+    .then(console.log);

--- a/scripts/generate-sats-icons-from-vector-drawables.js
+++ b/scripts/generate-sats-icons-from-vector-drawables.js
@@ -16,7 +16,7 @@ function generateSatsIconsObject(filenames) {
     ].sort().join('\n') + '\n\n';
 
     const propertiesDeclaration = filenames.map(filename => {
-        const propertyName = camelize(filename);
+        const propertyName = fixNameIfNeeded(camelize(filename));
         const resName = filename.replace(".xml", "");
         const indent = '    '
 
@@ -40,6 +40,14 @@ function camelize(str) {
         .replace("ic_", "")
         .replace(".xml", "")
         .replace(/_([a-z]+)/g, (_, match) => match[0].toUpperCase() + match.substring(1));
+}
+
+function fixNameIfNeeded(str) {
+    if (str === "class") {
+        return "classFilled"
+    }
+
+    return str;
 }
 
 readAndroidVectorDrawables()


### PR DESCRIPTION
Given that https://github.com/sats-group/sats-dna-android/pull/406, generate a `SatsIcons.kt` file with references to all the icons.