### PR TITLE
NMA-6509: Fix shape and padding in challenge card. And prefix it with sats

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ChallengeCardSampleScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.sats.dna.components.card.ChallengeCard
-import com.sats.dna.components.card.ChallengeCardState
+import com.sats.dna.components.card.SatsChallengeCard
+import com.sats.dna.components.card.SatsChallengeCardState
 import com.sats.dna.theme.SatsTheme
 
 data object ChallengeCardSampleScreen : SampleScreen(
@@ -35,8 +35,8 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
             verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            ChallengeCard(
-                ChallengeCardState.Available(
+            SatsChallengeCard(
+                SatsChallengeCardState.Available(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     subtitle = "Workout for 7 consecutive days",
@@ -50,8 +50,8 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
                     .width(176.dp),
             )
 
-            ChallengeCard(
-                ChallengeCardState.Joined(
+            SatsChallengeCard(
+                SatsChallengeCardState.Joined(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     tagText = "23 days left!",
@@ -64,8 +64,8 @@ private fun ChallengeCardScreen(navigateUp: () -> Unit, modifier: Modifier = Mod
                     .width(176.dp),
             )
 
-            ChallengeCard(
-                ChallengeCardState.Disabled(
+            SatsChallengeCard(
+                SatsChallengeCardState.Disabled(
                     imageUrl = null,
                     title = "STREAK WEEK",
                     statusText = "Not completed",

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
@@ -122,7 +122,12 @@ private fun ChallengeCardLayout(
     bottomContent: @Composable (() -> Unit?)? = null,
 ) {
     CompositionLocalProvider(LocalUseMaterial3 provides true) {
-        SatsChallengeBackground(isEnabled = isEnabled, modifier = modifier.height(IntrinsicSize.Min)) {
+        SatsChallengeBackground(
+            isEnabled = isEnabled,
+            modifier = modifier
+                .height(IntrinsicSize.Min)
+                .clip(SatsTheme.shapes.roundedCorners.small),
+        ) {
             Column(
                 Modifier
                     .fillMaxSize()
@@ -171,6 +176,7 @@ private fun ChallengeCardLayout(
                     )
                     subtitle?.let {
                         Text(
+                            modifier = Modifier.padding(horizontal = SatsTheme.spacing.xxs),
                             text = subtitle,
                             style = SatsTheme.typography.normal.small,
                             textAlign = TextAlign.Center,

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
@@ -35,9 +35,9 @@ import com.sats.dna.components.progressbar.SatsLinearProgressBar
 import com.sats.dna.theme.SatsTheme
 
 @Composable
-fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
+fun SatsChallengeCard(state: SatsChallengeCardState, modifier: Modifier = Modifier) {
     when (state) {
-        is ChallengeCardState.Available -> {
+        is SatsChallengeCardState.Available -> {
             AvailableChallengeCard(
                 imageUrl = state.imageUrl,
                 title = state.title,
@@ -50,7 +50,7 @@ fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
             )
         }
 
-        is ChallengeCardState.Joined -> {
+        is SatsChallengeCardState.Joined -> {
             JoinedChallengeCard(
                 imageUrl = state.imageUrl,
                 title = state.title,
@@ -62,7 +62,7 @@ fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
             )
         }
 
-        is ChallengeCardState.Disabled -> {
+        is SatsChallengeCardState.Disabled -> {
             DisabledChallengeCard(
                 imageUrl = state.imageUrl,
                 title = state.title,
@@ -76,7 +76,7 @@ fun ChallengeCard(state: ChallengeCardState, modifier: Modifier = Modifier) {
     }
 }
 
-sealed interface ChallengeCardState {
+sealed interface SatsChallengeCardState {
     class Available(
         val imageUrl: String?,
         val title: String,
@@ -86,7 +86,7 @@ sealed interface ChallengeCardState {
         val onCardClick: () -> Unit,
         val onJoinClick: () -> Unit,
         val modifier: Modifier = Modifier,
-    ) : ChallengeCardState
+    ) : SatsChallengeCardState
 
     class Joined(
         val imageUrl: String?,
@@ -96,7 +96,7 @@ sealed interface ChallengeCardState {
         val statusText: String,
         val onCardClick: () -> Unit,
         val modifier: Modifier = Modifier,
-    ) : ChallengeCardState
+    ) : SatsChallengeCardState
 
     class Disabled(
         val imageUrl: String?,
@@ -106,7 +106,7 @@ sealed interface ChallengeCardState {
         val onCardClick: () -> Unit,
         val onDismissClicked: () -> Unit,
         val modifier: Modifier = Modifier,
-    ) : ChallengeCardState
+    ) : SatsChallengeCardState
 }
 
 @Composable
@@ -320,8 +320,8 @@ private fun ChallengeCardProgress(progress: Float, progressText: String, modifie
 @Composable
 private fun JoinChallengeCardPreview() {
     SatsTheme {
-        ChallengeCard(
-            ChallengeCardState.Available(
+        SatsChallengeCard(
+            SatsChallengeCardState.Available(
                 imageUrl = null,
                 title = "STREAK WEEK",
                 subtitle = "Workout for 7 consecutive days",
@@ -341,8 +341,8 @@ private fun JoinChallengeCardPreview() {
 @Composable
 private fun JoinedChallengeCardPreview() {
     SatsTheme {
-        ChallengeCard(
-            ChallengeCardState.Joined(
+        SatsChallengeCard(
+            SatsChallengeCardState.Joined(
                 imageUrl = null,
                 title = "STREAK WEEK STREAK WEEK STREAK WEEK",
                 tagText = "23 days left!",
@@ -361,8 +361,8 @@ private fun JoinedChallengeCardPreview() {
 @Composable
 private fun DisabledChallengeCardPreview() {
     SatsTheme {
-        ChallengeCard(
-            ChallengeCardState.Disabled(
+        SatsChallengeCard(
+            SatsChallengeCardState.Disabled(
                 imageUrl = null,
                 title = "STREAK WEEK",
                 statusText = "Not completed",


### PR DESCRIPTION
### What's new?
* Adds Sats prefix to ChallengeCard component.
* Add horizontal padding to subtitle so it doesn't touch edges when long
* Add small rounded corner shape to challenge card. 

**Before**: 
<img src="https://github.com/sats-group/sats-dna-android/assets/48335680/068cea1e-97b8-4fba-9a22-8d10c576c98b" width=40% />
**After:**
<img src="https://github.com/sats-group/sats-dna-android/assets/48335680/5b51d7fc-8d30-4a45-9e0d-df429f4530b5" width=40% />
