### PR TITLE
NMA-6568: Tweak challenge background so it doesn't have a size of it's own

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChallengeBackground.kt
@@ -1,16 +1,12 @@
 package com.sats.dna.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.draw.paint
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.sats.dna.GreyScaleModifier
 import com.sats.dna.R
@@ -20,32 +16,24 @@ import com.sats.dna.theme.SatsTheme
 fun SatsChallengeBackground(modifier: Modifier = Modifier, isEnabled: Boolean = true, content: @Composable () -> Unit) {
     SatsSurface(
         modifier = if (!isEnabled) {
-            modifier.greyScale()
+            modifier.then(GreyScaleModifier())
         } else {
             modifier
         },
         color = SatsTheme.colors.backgrounds.fixed.primary.default.bg,
         useMaterial3 = true,
     ) {
-        Box {
-            Image(
-                imageVector = ImageVector.vectorResource(R.drawable.challenge_background_top),
-                contentDescription = null,
-                modifier = Modifier.fillMaxWidth(),
+        Box(
+            Modifier.paint(
+                painter = painterResource(R.drawable.challenge_background_top),
+                sizeToIntrinsics = false,
                 contentScale = ContentScale.FillBounds,
-                colorFilter = if (!isEnabled) {
-                    ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
-                } else {
-                    null
-                },
-            )
-
+            ),
+        ) {
             content()
         }
     }
 }
-
-fun Modifier.greyScale() = this.then(GreyScaleModifier())
 
 @Preview
 @Preview(device = "spec:id=reference_tablet,shape=Normal,width=1280,height=800,unit=dp,dpi=240")

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
@@ -68,7 +68,7 @@ fun SatsChallengeCard(state: SatsChallengeCardState, modifier: Modifier = Modifi
                 title = state.title,
                 statusText = state.statusText,
                 onCardClick = state.onCardClick,
-                onDismissClicked = state.onDismissClicked,
+                onDismissClick = state.onDismissClicked,
                 dismissLabel = state.dismissLabel,
                 modifier = modifier,
             )
@@ -272,7 +272,7 @@ private fun DisabledChallengeCard(
     statusText: String,
     dismissLabel: String,
     onCardClick: () -> Unit,
-    onDismissClicked: () -> Unit,
+    onDismissClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ChallengeCardLayout(
@@ -283,7 +283,7 @@ private fun DisabledChallengeCard(
         isEnabled = false,
         dismissButton = {
             SatsDismissButton(
-                onDismissClicked = onDismissClicked,
+                onDismissClicked = onDismissClick,
                 dismissLabel = dismissLabel,
             )
         },

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/card/SatsChallengeCard.kt
@@ -85,7 +85,6 @@ sealed interface SatsChallengeCardState {
         val buttonText: String,
         val onCardClick: () -> Unit,
         val onJoinClick: () -> Unit,
-        val modifier: Modifier = Modifier,
     ) : SatsChallengeCardState
 
     class Joined(
@@ -95,7 +94,6 @@ sealed interface SatsChallengeCardState {
         val progress: Float,
         val statusText: String,
         val onCardClick: () -> Unit,
-        val modifier: Modifier = Modifier,
     ) : SatsChallengeCardState
 
     class Disabled(
@@ -105,7 +103,6 @@ sealed interface SatsChallengeCardState {
         val dismissLabel: String,
         val onCardClick: () -> Unit,
         val onDismissClicked: () -> Unit,
-        val modifier: Modifier = Modifier,
     ) : SatsChallengeCardState
 }
 


### PR DESCRIPTION
### What's new? 
When using the SatsChallengeCard, without setting both an explicit height and width the card would size itself to the size of the image svg. This PR fixes that so that the challenge background will just size itself to whatever the content size is.

Also removed an unused modifier parameter from the state objects and renamed the dismiss callback to be inline with the other callbacks.