### PR TITLE
NMA-6588: Create a SatsLinearProgressIndicator with correct default colors

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProgressBarsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/ProgressBarsSampleScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsCircularProgressIndicator
 import com.sats.dna.components.progressbar.SatsCircularSteppedProgressIndicator
 import com.sats.dna.components.progressbar.SatsLinearProgressBar
+import com.sats.dna.components.progressbar.SatsLinearProgressIndicator
 import com.sats.dna.components.progressbar.SteppingProgress
 import com.sats.dna.components.progressbar.SteppingProgressGroup
 import com.sats.dna.theme.SatsTheme
@@ -45,6 +46,10 @@ private fun ProgressBarsScreen(navigateUp: () -> Unit, modifier: Modifier = Modi
                     SatsLinearProgressBar(1.00f, Modifier.fillMaxWidth())
                     SatsLinearProgressBar(1.00f, Modifier.fillMaxWidth())
                 }
+            }
+
+            Section("Linear Progress Indicator") {
+                SatsLinearProgressIndicator(Modifier.fillMaxWidth())
             }
 
             Section("Circular Progress Indicator") {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressIndicator.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/progressbar/SatsLinearProgressIndicator.kt
@@ -1,0 +1,27 @@
+package com.sats.dna.components.progressbar
+
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun SatsLinearProgressIndicator(
+    modifier: Modifier = Modifier,
+    strokeCap: StrokeCap = StrokeCap.Round,
+) {
+    LinearProgressIndicator(
+        color = SatsTheme.colors.graphicalElements.progressBar.default.fg,
+        trackColor = SatsTheme.colors.graphicalElements.progressBar.default.bg,
+        strokeCap = strokeCap,
+        modifier = modifier,
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsLinearProgressIndicatorPreview() {
+    SatsLinearProgressIndicator()
+}


### PR DESCRIPTION
### What's new?
* Add a SatsLinearProgressIndicator with correct default colors


https://github.com/sats-group/sats-dna-android/assets/48335680/d009fe08-5dc1-48bf-855b-30bf2094340e

