### PR TITLE
NMA-6634: Use new alpha release of androidx.navigation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanist = "0.34.0"
 agp = "8.3.2"
-androidx-navigation = "2.7.7"
+androidx-navigation = "2.8.0-alpha07"
 compose-compiler = "1.5.11"
 kotlin = "1.9.23"
 


### PR DESCRIPTION
This introduces predictive back handling by default.
