### PR TITLE
NMA-6683: Fix color of profile avatar image fallback

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsProfileAvatarImage.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsProfileAvatarImage.kt
@@ -43,7 +43,12 @@ fun SatsProfileAvatarImagePlaceholder(modifier: Modifier = Modifier) {
 
 @Composable
 private fun SatsProfileAvatarImageFallback(modifier: Modifier = Modifier) {
-    Icon(SatsIcons.Profilefilled, contentDescription = null, modifier)
+    Icon(
+        imageVector = SatsIcons.Profilefilled,
+        contentDescription = null,
+        tint = SatsTheme.colors.graphicalElements.icons.secondary,
+        modifier = modifier,
+    )
 }
 
 @PreviewLightDark


### PR DESCRIPTION
### What's new?
* The profile avatar image fallback had some wonky colors (was completely white in dark mode which looked quite intense) now they don't 🙏