### PR TITLE
NMA-6684: Downgrade Compose to 1.7.0-alpha06

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ accompanist-insetsUi = { module = "com.google.accompanist:accompanist-insets-ui"
 accompanist-systemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 android-desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.4"
 androidx-activity-compose = "androidx.activity:activity-compose:1.9.0"
-androidx-compose-bom = "dev.chrisbanes.compose:compose-bom:2024.04.00-alpha02"
+androidx-compose-bom = "dev.chrisbanes.compose:compose-bom:2024.04.00-alpha01"
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }


### PR DESCRIPTION
There was a bug introduced in alpha07, which causes a decent amount of crashes in production for us when animating floats. It's been fixed in alpha08, but it's probably better to just downgrade for now and make a hotfix.