### PR TITLE
NMA-6705: Fix content color for primary disabled button

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors.kt
@@ -76,7 +76,7 @@ internal val SatsDarkColors = SatsColors(
     buttons = SatsColors.Buttons(
         primary = SatsColors.Buttons.Primary(
             default = SatsBlue100 on White100,
-            disabled = SatsBlue100 on White10,
+            disabled = Black50 on White10,
         ),
         secondary = SatsColors.Buttons.Secondary(
             default = OutlinedColorSet(


### PR DESCRIPTION
| Before | After |
| - | - |
| ![image](https://github.com/sats-group/sats-dna-android/assets/386122/cefa2912-12b3-40cd-b3dd-e6a6c6ef8167) | ![image](https://github.com/sats-group/sats-dna-android/assets/386122/60450f7f-55dd-4d4e-b899-965524248274) |
