### PR TITLE
NMA-6714: Some color changes and fixes

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/styles/ColorsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/styles/ColorsSampleScreen.kt
@@ -166,7 +166,7 @@ private fun ButtonsActionSamples(modifier: Modifier = Modifier) {
 
 @Composable
 private fun ButtonsFixedActionSamples(modifier: Modifier = Modifier) {
-    Subsection("Action", modifier) {
+    Subsection("Fixed Action", modifier, isFixed = true) {
         val action = SatsTheme.colors.buttons.fixedAction
 
         ColorSample(action.default, "default")
@@ -459,7 +459,7 @@ private fun GraphicalElementsBadgeSamples(modifier: Modifier = Modifier) {
 private fun GraphicalElementsFixedBadgeSamples(modifier: Modifier = Modifier) {
     val fixedBadge = SatsTheme.colors.graphicalElements.fixedBadge
 
-    Subsection("Fixed Badge", modifier) {
+    Subsection("Fixed Badge", modifier, isFixed = true) {
         ColorSample(fixedBadge.primary, "primary")
         ColorSample(fixedBadge.secondary, "secondary")
         ColorSample(fixedBadge.tertiary, "tertiary")

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
@@ -463,14 +463,14 @@ class SatsColors(
                     bg = SatsBlue105,
                     fg = White100,
                     fgAlternate = White60,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                 )
 
                 val selected: BackgroundColorSet = BackgroundColorSet(
                     bg = SatsBlue90,
                     fg = White100,
                     fgAlternate = White60,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                 )
             }
 
@@ -479,14 +479,14 @@ class SatsColors(
                     bg = SatsBlue100,
                     fg = White100,
                     fgAlternate = White60,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                 )
 
                 val selected: BackgroundColorSet = BackgroundColorSet(
                     bg = SatsBlueGrey80,
                     fg = White100,
                     fgAlternate = White60,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                 )
             }
         }
@@ -518,7 +518,7 @@ class SatsColors(
                     bg = SatsBlue100,
                     fg = White100,
                     fgAlternate = White65,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                     fgSuccess = SpringGreen60,
                     fgWarning = Gold60,
                     fgError = Cardinal60,
@@ -532,7 +532,7 @@ class SatsColors(
                     bg = SatsBlueGrey80,
                     fg = White100,
                     fgAlternate = White65,
-                    fgDisabled = White40,
+                    fgDisabled = White50,
                     fgSuccess = SpringGreen60,
                     fgWarning = Gold60,
                     fgError = Cardinal60,

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsColors.kt
@@ -1,6 +1,34 @@
 package com.sats.dna.colors
 
 import androidx.compose.ui.graphics.Color
+import com.sats.dna.colors.SatsColorPrimitives.BrightBlue10
+import com.sats.dna.colors.SatsColorPrimitives.BrightBlue60
+import com.sats.dna.colors.SatsColorPrimitives.Cardinal60
+import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple40
+import com.sats.dna.colors.SatsColorPrimitives.Gold60
+import com.sats.dna.colors.SatsColorPrimitives.SatsBlue10
+import com.sats.dna.colors.SatsColorPrimitives.SatsBlue100
+import com.sats.dna.colors.SatsColorPrimitives.SatsBlue105
+import com.sats.dna.colors.SatsColorPrimitives.SatsBlue90
+import com.sats.dna.colors.SatsColorPrimitives.SatsBlueGrey80
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral100
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral120
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral130
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral170
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral190
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral60
+import com.sats.dna.colors.SatsColorPrimitives.SatsCoral90
+import com.sats.dna.colors.SatsColorPrimitives.SpringGreen60
+import com.sats.dna.colors.SatsColorPrimitives.White0
+import com.sats.dna.colors.SatsColorPrimitives.White10
+import com.sats.dna.colors.SatsColorPrimitives.White100
+import com.sats.dna.colors.SatsColorPrimitives.White15
+import com.sats.dna.colors.SatsColorPrimitives.White40
+import com.sats.dna.colors.SatsColorPrimitives.White5
+import com.sats.dna.colors.SatsColorPrimitives.White50
+import com.sats.dna.colors.SatsColorPrimitives.White60
+import com.sats.dna.colors.SatsColorPrimitives.White65
+import com.sats.dna.colors.SatsColorPrimitives.White70
 
 class SatsColors(
     val buttons: Buttons,
@@ -13,15 +41,16 @@ class SatsColors(
     class Buttons(
         val primary: Primary,
         val secondary: Secondary,
-        val clean: Clean,
-        val cleanSecondary: CleanSecondary,
         val action: Action,
-        val fixedAction: FixedAction,
         val cta: Cta,
         val waitingListFilled: WaitingListFilled,
         val waitingListOutlined: WaitingListOutlined,
         val destructive: Destructive,
     ) {
+        val clean: Clean = Clean()
+        val cleanSecondary: CleanSecondary = CleanSecondary()
+        val fixedAction: FixedAction = FixedAction()
+
         class Primary(
             val default: ColorSet,
             val disabled: ColorSet,
@@ -32,25 +61,34 @@ class SatsColors(
             val disabled: OutlinedColorSet,
         )
 
-        class Clean(
-            val default: ColorSet,
-            val disabled: ColorSet,
-        )
+        class Clean {
+            val default: ColorSet = SatsBlue100 on White100
+            val disabled: ColorSet = White50 on White10
+        }
 
-        class CleanSecondary(
-            val default: OutlinedColorSet,
-            val disabled: OutlinedColorSet,
-        )
+        class CleanSecondary {
+            val default: OutlinedColorSet = OutlinedColorSet(
+                bg = White15,
+                outline = White100,
+                fg = White100,
+            )
+
+            val disabled: OutlinedColorSet = OutlinedColorSet(
+                bg = White5,
+                outline = White40,
+                fg = White70,
+            )
+        }
 
         class Action(
             val default: ColorSet,
             val disabled: ColorSet,
         )
 
-        class FixedAction(
-            val default: ColorSet,
-            val disabled: ColorSet,
-        )
+        class FixedAction {
+            val default = SatsCoral100 on White0
+            val disabled = White50 on White0
+        }
 
         class Cta(
             val default: ColorSet,
@@ -90,10 +128,8 @@ class SatsColors(
         val skeleton: Color,
         val navBar: NavBar,
         val progressBar: ProgressBar,
-        val fixedProgressBar: FixedProgressBar,
         val graphs: Graphs,
         val selector: Selector,
-        val selectorFixed: SelectorFixed,
         val chips: Chips,
         val toggle: Toggle,
         val icons: Icons,
@@ -102,10 +138,13 @@ class SatsColors(
         val tags: Tags,
         val indicatorTag: IndicatorTag,
         val badge: Badge,
-        val fixedBadge: FixedBadge,
         val rewards: Rewards,
         val workouts: Workouts,
     ) {
+        val fixedProgressBar: FixedProgressBar = FixedProgressBar()
+        val selectorFixed: SelectorFixed = SelectorFixed()
+        val fixedBadge: FixedBadge = FixedBadge()
+
         class Divider(
             val default: Color,
             val alternate: Color,
@@ -136,10 +175,10 @@ class SatsColors(
             val alternate: ColorSet,
         )
 
-        class FixedProgressBar(
-            val default: ColorSet,
-            val alternate: ColorSet,
-        )
+        class FixedProgressBar {
+            val default: ColorSet = SatsCoral90 on White40
+            val alternate: ColorSet = SatsBlue10 on White40
+        }
 
         class Graphs(
             val bar: Bar,
@@ -226,25 +265,25 @@ class SatsColors(
             }
         }
 
-        class SelectorFixed(
-            val unselected: Unselected,
-            val selected: Selected,
-            val selectedBackground: SelectedBackground,
-        ) {
-            class Unselected(
-                val default: OutlinedColorSet,
-                val disabled: OutlinedColorSet,
-            )
+        class SelectorFixed {
+            val unselected: Unselected = Unselected()
+            val selected: Selected = Selected()
+            val selectedBackground: SelectedBackground = SelectedBackground()
 
-            class Selected(
-                val default: ColorSet,
-                val disabled: ColorSet,
-            )
+            class Unselected {
+                val default = OutlinedColorSet(outline = White100, bg = White0, fg = White100)
+                val disabled = OutlinedColorSet(outline = White50, bg = White0, fg = White50)
+            }
 
-            class SelectedBackground(
-                val default: Color,
-                val disabled: Color,
-            )
+            class Selected {
+                val default: ColorSet = SatsBlue100 on SatsCoral90
+                val disabled: ColorSet = SatsCoral170 on SatsCoral130
+            }
+
+            class SelectedBackground {
+                val default: Color = SatsCoral170
+                val disabled: Color = SatsCoral190
+            }
         }
 
         class Chips(
@@ -281,13 +320,14 @@ class SatsColors(
         class Icons(
             val primary: Color,
             val secondary: Color,
-            val fixed: Color,
             val positive: Color,
             val attention: Color,
             val negative: Color,
             val waitingList: Color,
             val delete: Color,
-        )
+        ) {
+            val fixed: Color = White100
+        }
 
         class Indicators(
             val positive: Positive,
@@ -375,11 +415,11 @@ class SatsColors(
             val tertiary: ColorSet,
         )
 
-        class FixedBadge(
-            val primary: ColorSet,
-            val secondary: ColorSet,
-            val tertiary: ColorSet,
-        )
+        class FixedBadge {
+            val primary: ColorSet = White100 on SatsCoral120
+            val secondary: ColorSet = SatsBlue100 on BrightBlue10
+            val tertiary: ColorSet = White100 on SatsBlueGrey80
+        }
 
         class Rewards(
             val blue: ColorSet,
@@ -401,8 +441,9 @@ class SatsColors(
     class Backgrounds(
         val primary: Primary,
         val secondary: Secondary,
-        val fixed: Fixed,
     ) {
+        val fixed: Fixed = Fixed()
+
         class Primary(
             val default: BackgroundColorSet,
             val selected: BackgroundColorSet,
@@ -413,27 +454,50 @@ class SatsColors(
             val selected: BackgroundColorSet,
         )
 
-        class Fixed(
-            val primary: Primary,
-            val secondary: Secondary,
-        ) {
-            class Primary(
-                val default: BackgroundColorSet,
-                val selected: BackgroundColorSet,
-            )
+        class Fixed {
+            val primary: Primary = Primary()
+            val secondary: Secondary = Secondary()
 
-            class Secondary(
-                val default: BackgroundColorSet,
-                val selected: BackgroundColorSet,
-            )
+            class Primary {
+                val default: BackgroundColorSet = BackgroundColorSet(
+                    bg = SatsBlue105,
+                    fg = White100,
+                    fgAlternate = White60,
+                    fgDisabled = White40,
+                )
+
+                val selected: BackgroundColorSet = BackgroundColorSet(
+                    bg = SatsBlue90,
+                    fg = White100,
+                    fgAlternate = White60,
+                    fgDisabled = White40,
+                )
+            }
+
+            class Secondary {
+                val default: BackgroundColorSet = BackgroundColorSet(
+                    bg = SatsBlue100,
+                    fg = White100,
+                    fgAlternate = White60,
+                    fgDisabled = White40,
+                )
+
+                val selected: BackgroundColorSet = BackgroundColorSet(
+                    bg = SatsBlueGrey80,
+                    fg = White100,
+                    fgAlternate = White60,
+                    fgDisabled = White40,
+                )
+            }
         }
     }
 
     class Surfaces(
         val primary: Primary,
         val secondary: Secondary,
-        val fixed: Fixed,
     ) {
+        val fixed: Fixed = Fixed()
+
         class Primary(
             val default: SurfaceColorSet,
             val selected: SurfaceColorSet,
@@ -445,19 +509,69 @@ class SatsColors(
             val selected: SurfaceColorSet,
         )
 
-        class Fixed(
-            val primary: Primary,
-            val secondary: Secondary,
-        ) {
-            class Primary(
-                val default: SurfaceColorSet,
-                val selected: SurfaceColorSet,
-            )
+        class Fixed {
+            val primary: Primary = Primary()
+            val secondary: Secondary = Secondary()
 
-            class Secondary(
-                val default: SurfaceColorSet,
-                val selected: SurfaceColorSet,
-            )
+            class Primary {
+                val default: SurfaceColorSet = SurfaceColorSet(
+                    bg = SatsBlue100,
+                    fg = White100,
+                    fgAlternate = White65,
+                    fgDisabled = White40,
+                    fgSuccess = SpringGreen60,
+                    fgWarning = Gold60,
+                    fgError = Cardinal60,
+                    fgWaitingList = EgyptianPurple40,
+                    fgNeutral = White60,
+                    fgInformation = BrightBlue60,
+                    fgFeatured = SatsCoral60,
+                )
+
+                val selected: SurfaceColorSet = SurfaceColorSet(
+                    bg = SatsBlueGrey80,
+                    fg = White100,
+                    fgAlternate = White65,
+                    fgDisabled = White40,
+                    fgSuccess = SpringGreen60,
+                    fgWarning = Gold60,
+                    fgError = Cardinal60,
+                    fgWaitingList = EgyptianPurple40,
+                    fgNeutral = White60,
+                    fgInformation = BrightBlue60,
+                    fgFeatured = SatsCoral60,
+                )
+            }
+
+            class Secondary {
+                val default: SurfaceColorSet = SurfaceColorSet(
+                    bg = SatsBlueGrey80,
+                    fg = White100,
+                    fgAlternate = White65,
+                    fgDisabled = White40,
+                    fgSuccess = SpringGreen60,
+                    fgWarning = Gold60,
+                    fgError = Cardinal60,
+                    fgWaitingList = EgyptianPurple40,
+                    fgNeutral = White60,
+                    fgInformation = BrightBlue60,
+                    fgFeatured = SatsCoral60,
+                )
+
+                val selected: SurfaceColorSet = SurfaceColorSet(
+                    bg = SatsBlueGrey80,
+                    fg = White100,
+                    fgAlternate = White65,
+                    fgDisabled = White40,
+                    fgSuccess = SpringGreen60,
+                    fgWarning = Gold60,
+                    fgError = Cardinal60,
+                    fgWaitingList = EgyptianPurple40,
+                    fgNeutral = White60,
+                    fgInformation = BrightBlue60,
+                    fgFeatured = SatsCoral60,
+                )
+            }
         }
     }
 

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsDarkColors.kt
@@ -10,7 +10,6 @@ import com.sats.dna.colors.SatsColorPrimitives.Black80
 import com.sats.dna.colors.SatsColorPrimitives.Black85
 import com.sats.dna.colors.SatsColorPrimitives.Black90
 import com.sats.dna.colors.SatsColorPrimitives.Black95
-import com.sats.dna.colors.SatsColorPrimitives.BrightBlue10
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue100
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue160
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue170
@@ -25,36 +24,28 @@ import com.sats.dna.colors.SatsColorPrimitives.Celadon70
 import com.sats.dna.colors.SatsColorPrimitives.ChiliRed170
 import com.sats.dna.colors.SatsColorPrimitives.ChiliRed80
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple160
-import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple40
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple60
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple80
 import com.sats.dna.colors.SatsColorPrimitives.Gold100
 import com.sats.dna.colors.SatsColorPrimitives.Gold110
 import com.sats.dna.colors.SatsColorPrimitives.Gold170
 import com.sats.dna.colors.SatsColorPrimitives.Gold30
-import com.sats.dna.colors.SatsColorPrimitives.Gold60
 import com.sats.dna.colors.SatsColorPrimitives.Gold80
 import com.sats.dna.colors.SatsColorPrimitives.SalmonPink70
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue10
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue100
-import com.sats.dna.colors.SatsColorPrimitives.SatsBlue105
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue20
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue40
-import com.sats.dna.colors.SatsColorPrimitives.SatsBlue90
-import com.sats.dna.colors.SatsColorPrimitives.SatsBlueGrey80
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral100
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral120
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral130
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral170
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral190
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral40
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral60
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral90
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen10
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen100
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen170
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen30
-import com.sats.dna.colors.SatsColorPrimitives.SpringGreen60
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen80
 import com.sats.dna.colors.SatsColorPrimitives.Tangerine70
 import com.sats.dna.colors.SatsColorPrimitives.TropicalIndigo70
@@ -62,13 +53,9 @@ import com.sats.dna.colors.SatsColorPrimitives.UranianBlue70
 import com.sats.dna.colors.SatsColorPrimitives.White0
 import com.sats.dna.colors.SatsColorPrimitives.White10
 import com.sats.dna.colors.SatsColorPrimitives.White100
-import com.sats.dna.colors.SatsColorPrimitives.White15
 import com.sats.dna.colors.SatsColorPrimitives.White20
 import com.sats.dna.colors.SatsColorPrimitives.White40
-import com.sats.dna.colors.SatsColorPrimitives.White5
-import com.sats.dna.colors.SatsColorPrimitives.White50
 import com.sats.dna.colors.SatsColorPrimitives.White60
-import com.sats.dna.colors.SatsColorPrimitives.White65
 import com.sats.dna.colors.SatsColorPrimitives.White70
 import com.sats.dna.colors.SatsColorPrimitives.White85
 
@@ -90,27 +77,7 @@ internal val SatsDarkColors = SatsColors(
                 fg = Black50,
             ),
         ),
-        clean = SatsColors.Buttons.Clean(
-            default = SatsBlue100 on White100,
-            disabled = White50 on White10,
-        ),
-        cleanSecondary = SatsColors.Buttons.CleanSecondary(
-            default = OutlinedColorSet(
-                bg = White15,
-                outline = White100,
-                fg = White100,
-            ),
-            disabled = OutlinedColorSet(
-                bg = White5,
-                outline = White40,
-                fg = White70,
-            ),
-        ),
         action = SatsColors.Buttons.Action(
-            default = SatsCoral100 on White0,
-            disabled = Black50 on White0,
-        ),
-        fixedAction = SatsColors.Buttons.FixedAction(
             default = SatsCoral100 on White0,
             disabled = Black50 on White0,
         ),
@@ -180,10 +147,6 @@ internal val SatsDarkColors = SatsColors(
             default = SatsCoral90 on Black70,
             alternate = SatsBlue10 on Black70,
         ),
-        fixedProgressBar = SatsColors.GraphicalElements.FixedProgressBar(
-            default = SatsCoral90 on White40,
-            alternate = SatsBlue10 on White40,
-        ),
         graphs = SatsColors.GraphicalElements.Graphs(
             bar = SatsColors.GraphicalElements.Graphs.Bar(
                 primary = SatsColors.GraphicalElements.Graphs.Bar.Primary(
@@ -239,20 +202,6 @@ internal val SatsDarkColors = SatsColors(
                 ),
             ),
         ),
-        selectorFixed = SatsColors.GraphicalElements.SelectorFixed(
-            unselected = SatsColors.GraphicalElements.SelectorFixed.Unselected(
-                default = OutlinedColorSet(outline = White100, bg = White0, fg = White100),
-                disabled = OutlinedColorSet(outline = White50, bg = White0, fg = White50),
-            ),
-            selected = SatsColors.GraphicalElements.SelectorFixed.Selected(
-                default = SatsBlue100 on SatsCoral90,
-                disabled = SatsCoral170 on SatsCoral130,
-            ),
-            selectedBackground = SatsColors.GraphicalElements.SelectorFixed.SelectedBackground(
-                default = SatsCoral170,
-                disabled = SatsCoral190,
-            ),
-        ),
         chips = SatsColors.GraphicalElements.Chips(
             unselected = SatsColors.GraphicalElements.Chips.Unselected(
                 default = OutlinedColorSet(outline = White85, bg = White0, fg = White100),
@@ -277,7 +226,6 @@ internal val SatsDarkColors = SatsColors(
         icons = SatsColors.GraphicalElements.Icons(
             primary = White100,
             secondary = Black20,
-            fixed = White100,
             positive = SpringGreen80,
             attention = Gold100,
             negative = Cardinal100,
@@ -345,11 +293,6 @@ internal val SatsDarkColors = SatsColors(
             secondary = SatsBlue100 on SatsBlue10,
             tertiary = White100 on Black80,
         ),
-        fixedBadge = SatsColors.GraphicalElements.FixedBadge(
-            primary = White100 on SatsCoral120,
-            secondary = SatsBlue100 on BrightBlue10,
-            tertiary = White100 on SatsBlueGrey80,
-        ),
         rewards = SatsColors.GraphicalElements.Rewards(
             blue = SatsBlue100 on BrightBlue100,
             silver = SatsBlue100 on SatsBlue20,
@@ -392,36 +335,6 @@ internal val SatsDarkColors = SatsColors(
                 fg = White100,
                 fgAlternate = Black20,
                 fgDisabled = Black50,
-            ),
-        ),
-        fixed = SatsColors.Backgrounds.Fixed(
-            primary = SatsColors.Backgrounds.Fixed.Primary(
-                default = BackgroundColorSet(
-                    bg = SatsBlue105,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-                selected = BackgroundColorSet(
-                    bg = SatsBlue90,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-            ),
-            secondary = SatsColors.Backgrounds.Fixed.Secondary(
-                default = BackgroundColorSet(
-                    bg = SatsBlue100,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-                selected = BackgroundColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
             ),
         ),
     ),
@@ -493,64 +406,6 @@ internal val SatsDarkColors = SatsColors(
                 fgNeutral = Black40,
                 fgInformation = BrightBlue60,
                 fgFeatured = SatsCoral90,
-            ),
-        ),
-        fixed = SatsColors.Surfaces.Fixed(
-            primary = SatsColors.Surfaces.Fixed.Primary(
-                default = SurfaceColorSet(
-                    bg = SatsBlue100,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-                selected = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-            ),
-            secondary = SatsColors.Surfaces.Fixed.Secondary(
-                default = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-                selected = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
             ),
         ),
     ),

--- a/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/colors/SatsLightColors.kt
@@ -12,12 +12,10 @@ import com.sats.dna.colors.SatsColorPrimitives.BrightBlue100
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue110
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue160
 import com.sats.dna.colors.SatsColorPrimitives.BrightBlue20
-import com.sats.dna.colors.SatsColorPrimitives.BrightBlue60
 import com.sats.dna.colors.SatsColorPrimitives.Cardinal10
 import com.sats.dna.colors.SatsColorPrimitives.Cardinal100
 import com.sats.dna.colors.SatsColorPrimitives.Cardinal120
 import com.sats.dna.colors.SatsColorPrimitives.Cardinal30
-import com.sats.dna.colors.SatsColorPrimitives.Cardinal60
 import com.sats.dna.colors.SatsColorPrimitives.CaribbeanCurrent100
 import com.sats.dna.colors.SatsColorPrimitives.Celadon100
 import com.sats.dna.colors.SatsColorPrimitives.ChiliRed100
@@ -25,7 +23,6 @@ import com.sats.dna.colors.SatsColorPrimitives.ChiliRed170
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple10
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple100
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple160
-import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple40
 import com.sats.dna.colors.SatsColorPrimitives.EgyptianPurple80
 import com.sats.dna.colors.SatsColorPrimitives.Gold10
 import com.sats.dna.colors.SatsColorPrimitives.Gold100
@@ -33,48 +30,32 @@ import com.sats.dna.colors.SatsColorPrimitives.Gold130
 import com.sats.dna.colors.SatsColorPrimitives.Gold140
 import com.sats.dna.colors.SatsColorPrimitives.Gold170
 import com.sats.dna.colors.SatsColorPrimitives.Gold30
-import com.sats.dna.colors.SatsColorPrimitives.Gold60
 import com.sats.dna.colors.SatsColorPrimitives.Gold80
 import com.sats.dna.colors.SatsColorPrimitives.SalmonPink100
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue10
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue100
-import com.sats.dna.colors.SatsColorPrimitives.SatsBlue105
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue20
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue40
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue5
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlue70
-import com.sats.dna.colors.SatsColorPrimitives.SatsBlue90
 import com.sats.dna.colors.SatsColorPrimitives.SatsBlueGrey80
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral10
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral100
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral120
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral130
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral170
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral190
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral40
 import com.sats.dna.colors.SatsColorPrimitives.SatsCoral5
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral60
-import com.sats.dna.colors.SatsColorPrimitives.SatsCoral90
 import com.sats.dna.colors.SatsColorPrimitives.SatsLightGrey15
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen10
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen100
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen120
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen170
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen30
-import com.sats.dna.colors.SatsColorPrimitives.SpringGreen60
 import com.sats.dna.colors.SatsColorPrimitives.SpringGreen80
 import com.sats.dna.colors.SatsColorPrimitives.Tangerine100
 import com.sats.dna.colors.SatsColorPrimitives.TropicalIndigo100
 import com.sats.dna.colors.SatsColorPrimitives.UranianBlue100
 import com.sats.dna.colors.SatsColorPrimitives.White0
 import com.sats.dna.colors.SatsColorPrimitives.White100
-import com.sats.dna.colors.SatsColorPrimitives.White15
-import com.sats.dna.colors.SatsColorPrimitives.White20
-import com.sats.dna.colors.SatsColorPrimitives.White40
-import com.sats.dna.colors.SatsColorPrimitives.White5
-import com.sats.dna.colors.SatsColorPrimitives.White50
-import com.sats.dna.colors.SatsColorPrimitives.White60
-import com.sats.dna.colors.SatsColorPrimitives.White65
 
 internal val SatsLightColors = SatsColors(
     buttons = SatsColors.Buttons(
@@ -94,29 +75,9 @@ internal val SatsLightColors = SatsColors(
                 fg = Black60,
             ),
         ),
-        clean = SatsColors.Buttons.Clean(
-            default = SatsBlue100 on White100,
-            disabled = White50 on White20,
-        ),
-        cleanSecondary = SatsColors.Buttons.CleanSecondary(
-            default = OutlinedColorSet(
-                bg = White15,
-                outline = White100,
-                fg = White100,
-            ),
-            disabled = OutlinedColorSet(
-                bg = White5,
-                outline = White40,
-                fg = White60,
-            ),
-        ),
         action = SatsColors.Buttons.Action(
             default = SatsCoral120 on White0,
             disabled = Black50 on White0,
-        ),
-        fixedAction = SatsColors.Buttons.FixedAction(
-            default = SatsCoral100 on White0,
-            disabled = White50 on White0,
         ),
         cta = SatsColors.Buttons.Cta(
             default = White100 on SatsCoral120,
@@ -184,10 +145,6 @@ internal val SatsLightColors = SatsColors(
             default = SatsCoral100 on SatsLightGrey15,
             alternate = SatsBlue100 on SatsLightGrey15,
         ),
-        fixedProgressBar = SatsColors.GraphicalElements.FixedProgressBar(
-            default = SatsCoral90 on White40,
-            alternate = SatsBlue10 on White40,
-        ),
         graphs = SatsColors.GraphicalElements.Graphs(
             bar = SatsColors.GraphicalElements.Graphs.Bar(
                 primary = SatsColors.GraphicalElements.Graphs.Bar.Primary(
@@ -243,20 +200,6 @@ internal val SatsLightColors = SatsColors(
                 ),
             ),
         ),
-        selectorFixed = SatsColors.GraphicalElements.SelectorFixed(
-            unselected = SatsColors.GraphicalElements.SelectorFixed.Unselected(
-                default = OutlinedColorSet(outline = White100, bg = White0, fg = White100),
-                disabled = OutlinedColorSet(outline = White50, bg = White0, fg = White50),
-            ),
-            selected = SatsColors.GraphicalElements.SelectorFixed.Selected(
-                default = SatsBlue100 on SatsCoral90,
-                disabled = SatsCoral170 on SatsCoral130,
-            ),
-            selectedBackground = SatsColors.GraphicalElements.SelectorFixed.SelectedBackground(
-                default = SatsCoral170,
-                disabled = SatsCoral190,
-            ),
-        ),
         chips = SatsColors.GraphicalElements.Chips(
             unselected = SatsColors.GraphicalElements.Chips.Unselected(
                 default = OutlinedColorSet(outline = SatsBlue40, bg = White0, fg = SatsBlue100),
@@ -281,7 +224,6 @@ internal val SatsLightColors = SatsColors(
         icons = SatsColors.GraphicalElements.Icons(
             primary = SatsBlue100,
             secondary = SatsBlueGrey80,
-            fixed = White100,
             positive = SpringGreen100,
             attention = Gold100,
             negative = Cardinal100,
@@ -349,11 +291,6 @@ internal val SatsLightColors = SatsColors(
             secondary = White100 on SatsBlue100,
             tertiary = SatsBlue100 on SatsBlue5,
         ),
-        fixedBadge = SatsColors.GraphicalElements.FixedBadge(
-            primary = White100 on SatsCoral120,
-            secondary = SatsBlue100 on BrightBlue10,
-            tertiary = White100 on SatsBlueGrey80,
-        ),
         rewards = SatsColors.GraphicalElements.Rewards(
             blue = White100 on SatsBlue100,
             silver = White100 on Black50,
@@ -396,36 +333,6 @@ internal val SatsLightColors = SatsColors(
                 fg = SatsBlue100,
                 fgAlternate = SatsBlue70,
                 fgDisabled = Black60,
-            ),
-        ),
-        fixed = SatsColors.Backgrounds.Fixed(
-            primary = SatsColors.Backgrounds.Fixed.Primary(
-                default = BackgroundColorSet(
-                    bg = SatsBlue105,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-                selected = BackgroundColorSet(
-                    bg = SatsBlue90,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-            ),
-            secondary = SatsColors.Backgrounds.Fixed.Secondary(
-                default = BackgroundColorSet(
-                    bg = SatsBlue100,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
-                selected = BackgroundColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White60,
-                    fgDisabled = White40,
-                ),
             ),
         ),
     ),
@@ -497,64 +404,6 @@ internal val SatsLightColors = SatsColors(
                 fgNeutral = Black60,
                 fgInformation = BrightBlue110,
                 fgFeatured = SatsCoral120,
-            ),
-        ),
-        fixed = SatsColors.Surfaces.Fixed(
-            primary = SatsColors.Surfaces.Fixed.Primary(
-                default = SurfaceColorSet(
-                    bg = SatsBlue100,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-                selected = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-            ),
-            secondary = SatsColors.Surfaces.Fixed.Secondary(
-                default = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
-                selected = SurfaceColorSet(
-                    bg = SatsBlueGrey80,
-                    fg = White100,
-                    fgAlternate = White65,
-                    fgDisabled = White40,
-                    fgSuccess = SpringGreen60,
-                    fgWarning = Gold60,
-                    fgError = Cardinal60,
-                    fgWaitingList = EgyptianPurple40,
-                    fgNeutral = White60,
-                    fgInformation = BrightBlue60,
-                    fgFeatured = SatsCoral60,
-                ),
             ),
         ),
     ),


### PR DESCRIPTION
- **Specify fixed/clean colors directly in SatsColors**
  These colors should, by design, always be the same in light and dark mode, so settings them in the light and dark color implementations of `SatsColors` just adds more possibilities of making mistakes. Instead,
setting them directly in `SatsColors` means they'll always be the same.

- **Show correct background behind colors in sample**
  Fixed content colors and clean buttons should always be on top of fixed backgrounds/surfaces, so that should be how they're represented in the sample app, as well.

- **Change on fixed disabled colors to match DS**
  Two color changes to ensure a11y compliance (AA).