### PR TITLE
NMA-6741: Use non-experimental strong skipping flag

### DIFF
--- a/sats-dna/build.gradle.kts
+++ b/sats-dna/build.gradle.kts
@@ -64,7 +64,7 @@ android {
     kotlinOptions {
         freeCompilerArgs += listOf(
             "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
+            "plugin:androidx.compose.compiler.plugins.kotlin:strongSkipping=true",
         )
     }
 


### PR DESCRIPTION
This feature is no longer experimental, so the flag changed.
