### PR TITLE
NMA-6798: Create SatsChoiceBox component

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/MainNavigation.kt
@@ -15,6 +15,7 @@ import com.sats.dna.sample.routes.components.ChallengeBadgeSampleScreenRoute
 import com.sats.dna.sample.routes.components.ChallengeCardSampleScreenRoute
 import com.sats.dna.sample.routes.components.CheckboxSampleScreenRoute
 import com.sats.dna.sample.routes.components.ChipsSampleScreenRoute
+import com.sats.dna.sample.routes.components.ChoiceBoxSampleScreenRoute
 import com.sats.dna.sample.routes.components.CompletedWorkoutListItemSampleScreenRoute
 import com.sats.dna.sample.routes.components.DividersSampleScreenRoute
 import com.sats.dna.sample.routes.components.EmptyStateSampleScreenRoute
@@ -57,6 +58,7 @@ import com.sats.dna.sample.screens.components.ChallengeBadgeSampleScreen
 import com.sats.dna.sample.screens.components.ChallengeCardSampleScreen
 import com.sats.dna.sample.screens.components.CheckboxSampleScreen
 import com.sats.dna.sample.screens.components.ChipsSampleScreen
+import com.sats.dna.sample.screens.components.ChoiceBoxSampleScreen
 import com.sats.dna.sample.screens.components.CompletedWorkoutListItemSampleScreen
 import com.sats.dna.sample.screens.components.DividersSampleScreen
 import com.sats.dna.sample.screens.components.EmptyStateSampleScreen
@@ -147,6 +149,10 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
 
     sampleAppComposable<ChipsSampleScreenRoute> {
         ChipsSampleScreen(navigateUp = navController::navigateUp)
+    }
+
+    sampleAppComposable<ChoiceBoxSampleScreenRoute> {
+        ChoiceBoxSampleScreen(navigateUp = navController::navigateUp)
     }
 
     sampleAppComposable<CompletedWorkoutListItemSampleScreenRoute> {

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/routes/components/ChoiceBoxSampleScreenRoute.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/routes/components/ChoiceBoxSampleScreenRoute.kt
@@ -1,0 +1,9 @@
+package com.sats.dna.sample.routes.components
+
+import com.sats.dna.sample.routes.SampleScreenRoute
+import kotlinx.serialization.Serializable
+
+@Serializable
+object ChoiceBoxSampleScreenRoute : SampleScreenRoute {
+    override val name: String = "ChoiceBox"
+}

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/HomeScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/HomeScreen.kt
@@ -61,6 +61,7 @@ import com.sats.dna.sample.routes.components.ChallengeBadgeSampleScreenRoute
 import com.sats.dna.sample.routes.components.ChallengeCardSampleScreenRoute
 import com.sats.dna.sample.routes.components.CheckboxSampleScreenRoute
 import com.sats.dna.sample.routes.components.ChipsSampleScreenRoute
+import com.sats.dna.sample.routes.components.ChoiceBoxSampleScreenRoute
 import com.sats.dna.sample.routes.components.CompletedWorkoutListItemSampleScreenRoute
 import com.sats.dna.sample.routes.components.DividersSampleScreenRoute
 import com.sats.dna.sample.routes.components.EmptyStateSampleScreenRoute
@@ -292,6 +293,7 @@ private val groups: Map<String, List<SampleScreenRoute>> = mapOf(
         ChallengeCardSampleScreenRoute,
         CheckboxSampleScreenRoute,
         ChipsSampleScreenRoute,
+        ChoiceBoxSampleScreenRoute,
         CompletedWorkoutListItemSampleScreenRoute,
         DividersSampleScreenRoute,
         EmptyStateSampleScreenRoute,

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/ChoiceBoxSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/ChoiceBoxSampleScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,7 +25,6 @@ import com.sats.dna.components.SatsChoiceBox
 import com.sats.dna.components.SatsChoiceBoxColor
 import com.sats.dna.components.SatsChoiceBoxStyle
 import com.sats.dna.components.SatsChoiceBoxType
-import com.sats.dna.components.SatsHorizontalDivider
 import com.sats.dna.components.SatsRadioButton
 import com.sats.dna.components.SatsSurface
 import com.sats.dna.components.SatsVerticalDivider
@@ -32,7 +33,6 @@ import com.sats.dna.theme.SatsTheme
 
 @Composable
 fun ChoiceBoxSampleScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
-
     var style by remember { mutableStateOf(SatsChoiceBoxStyle()) }
 
     SampleScreen("ChoiceBox", navigateUp, modifier) { innerPadding ->
@@ -43,145 +43,152 @@ fun ChoiceBoxSampleScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier)
                 SatsTheme.colors.backgrounds.primary.default.bg
             },
         ) {
-            Column(
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(SatsTheme.spacing.m),
-                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-
-                SatsHorizontalDivider()
-                Section("Unselected enabled") {
-                    var isSelected by rememberSaveable { mutableStateOf(false) }
-
-                    SatsChoiceBox(
-                        title = "Accept",
-                        description = "Description of whatever the user is accepting",
-                        isSelected = isSelected,
-                        isEnabled = true,
-                        style = style,
-                        onClick = {
-                            isSelected = !isSelected
-                        },
-                    )
-                }
-                Section("Selected enabled") {
-
-                    var isSelected by rememberSaveable { mutableStateOf(true) }
-
-                    SatsChoiceBox(
-                        title = "Accept",
-                        description = "Description of whatever the user is accepting",
-                        isSelected = isSelected,
-                        isEnabled = true,
-                        style = style,
-                        onClick = {
-                            isSelected = !isSelected
-                        },
-                    )
-                }
-
-                Section("Unselected disabled") {
-
-                    var isSelected by rememberSaveable { mutableStateOf(false) }
-
-                    SatsChoiceBox(
-                        title = "Accept",
-                        description = "Description of whatever the user is accepting",
-                        isSelected = isSelected,
-                        isEnabled = false,
-                        style = style,
-                        onClick = {
-                            isSelected = !isSelected
-                        },
-                    )
-                }
-                Section("Selected disabled") {
-                    var isSelected by rememberSaveable { mutableStateOf(true) }
-
-                    SatsChoiceBox(
-                        title = "Accept",
-                        description = "Description of whatever the user is accepting",
-                        isSelected = isSelected,
-                        isEnabled = false,
-                        style = style,
-                        onClick = {
-                            isSelected = !isSelected
-                        },
-                    )
-                }
-                Row(
-                    Modifier.height(IntrinsicSize.Min)
+            Column {
+                Column(
+                    Modifier
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState())
+                        .padding(innerPadding)
+                        .padding(SatsTheme.spacing.m),
+                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Column(
-                        Modifier.weight(1f),
-                    ) {
-                        Row(
-                            Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = "Radio",
-                            )
-                            SatsRadioButton(
-                                onClick = {
-                                    style = style.copy(choiceType = SatsChoiceBoxType.Radio)
-                                },
-                                selected = style.choiceType == SatsChoiceBoxType.Radio,
-                            )
-                        }
-                        Row(
-                            Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = "Check box",
-                            )
-                            SatsRadioButton(
-                                onClick = {
-                                    style = style.copy(choiceType = SatsChoiceBoxType.Checkbox)
-                                },
-                                selected = style.choiceType == SatsChoiceBoxType.Checkbox,
-                            )
-                        }
+                    Section("Unselected enabled") {
+                        var isSelected by rememberSaveable { mutableStateOf(false) }
+
+                        SatsChoiceBox(
+                            title = "Accept",
+                            description = "Description of whatever the user is accepting",
+                            isSelected = isSelected,
+                            isEnabled = true,
+                            style = style,
+                            onClick = {
+                                isSelected = !isSelected
+                            },
+                        )
                     }
-                    SatsVerticalDivider(Modifier.padding(SatsTheme.spacing.xs))
-                    Column(
-                        Modifier.weight(1f).padding(start = SatsTheme.spacing.s),
+                    Section("Selected enabled") {
+                        var isSelected by rememberSaveable { mutableStateOf(true) }
+
+                        SatsChoiceBox(
+                            title = "Accept",
+                            description = "Description of whatever the user is accepting",
+                            isSelected = isSelected,
+                            isEnabled = true,
+                            style = style,
+                            onClick = {
+                                isSelected = !isSelected
+                            },
+                        )
+                    }
+
+                    Section("Unselected disabled") {
+                        var isSelected by rememberSaveable { mutableStateOf(false) }
+
+                        SatsChoiceBox(
+                            title = "Accept",
+                            description = "Description of whatever the user is accepting",
+                            isSelected = isSelected,
+                            isEnabled = false,
+                            style = style,
+                            onClick = {
+                                isSelected = !isSelected
+                            },
+                        )
+                    }
+                    Section("Selected disabled") {
+                        var isSelected by rememberSaveable { mutableStateOf(true) }
+
+                        SatsChoiceBox(
+                            title = "Accept",
+                            description = "Description of whatever the user is accepting",
+                            isSelected = isSelected,
+                            isEnabled = false,
+                            style = style,
+                            onClick = {
+                                isSelected = !isSelected
+                            },
+                        )
+                    }
+                    Spacer(Modifier.weight(1f))
+                }
+                SatsSurface {
+                    Row(
+                        Modifier
+                            .height(IntrinsicSize.Min)
+                            .padding(bottom = innerPadding.calculateBottomPadding())
+                            .padding(SatsTheme.spacing.m),
                     ) {
-                        Row(
-                            Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        Column(
+                            Modifier.weight(1f),
                         ) {
-                            Text(
-                                text = "Default colors",
-                            )
-                            SatsRadioButton(
-                                onClick = {
-                                    style = style.copy(color = SatsChoiceBoxColor.Default)
-                                },
-                                selected = style.color == SatsChoiceBoxColor.Default,
-                            )
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Radio",
+                                )
+                                SatsRadioButton(
+                                    onClick = {
+                                        style = style.copy(choiceType = SatsChoiceBoxType.Radio)
+                                    },
+                                    selected = style.choiceType == SatsChoiceBoxType.Radio,
+                                )
+                            }
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Check box",
+                                )
+                                SatsRadioButton(
+                                    onClick = {
+                                        style = style.copy(choiceType = SatsChoiceBoxType.Checkbox)
+                                    },
+                                    selected = style.choiceType == SatsChoiceBoxType.Checkbox,
+                                )
+                            }
                         }
-                        Row(
-                            Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        SatsVerticalDivider(Modifier.padding(SatsTheme.spacing.xs))
+                        Column(
+                            Modifier
+                                .weight(1f)
+                                .padding(start = SatsTheme.spacing.s),
                         ) {
-                            Text(
-                                text = "Fixed Colors",
-                            )
-                            SatsRadioButton(
-                                onClick = {
-                                    style = style.copy(color = SatsChoiceBoxColor.Fixed)
-                                },
-                                selected = style.color == SatsChoiceBoxColor.Fixed,
-                            )
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Default colors",
+                                )
+                                SatsRadioButton(
+                                    onClick = {
+                                        style = style.copy(color = SatsChoiceBoxColor.Default)
+                                    },
+                                    selected = style.color == SatsChoiceBoxColor.Default,
+                                )
+                            }
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = "Fixed Colors",
+                                )
+                                SatsRadioButton(
+                                    onClick = {
+                                        style = style.copy(color = SatsChoiceBoxColor.Fixed)
+                                    },
+                                    selected = style.color == SatsChoiceBoxColor.Fixed,
+                                )
+                            }
                         }
                     }
                 }

--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/ChoiceBoxSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/ChoiceBoxSampleScreen.kt
@@ -1,0 +1,219 @@
+package com.sats.dna.sample.screens.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.sats.dna.components.SatsChoiceBox
+import com.sats.dna.components.SatsChoiceBoxColor
+import com.sats.dna.components.SatsChoiceBoxStyle
+import com.sats.dna.components.SatsChoiceBoxType
+import com.sats.dna.components.SatsHorizontalDivider
+import com.sats.dna.components.SatsRadioButton
+import com.sats.dna.components.SatsSurface
+import com.sats.dna.components.SatsVerticalDivider
+import com.sats.dna.sample.screens.SampleScreen
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun ChoiceBoxSampleScreen(navigateUp: () -> Unit, modifier: Modifier = Modifier) {
+
+    var style by remember { mutableStateOf(SatsChoiceBoxStyle()) }
+
+    SampleScreen("ChoiceBox", navigateUp, modifier) { innerPadding ->
+        SatsSurface(
+            color = if (style.color == SatsChoiceBoxColor.Fixed) {
+                SatsTheme.colors.backgrounds.fixed.primary.default.bg
+            } else {
+                SatsTheme.colors.backgrounds.primary.default.bg
+            },
+        ) {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+
+                SatsHorizontalDivider()
+                Section("Unselected enabled") {
+                    var isSelected by rememberSaveable { mutableStateOf(false) }
+
+                    SatsChoiceBox(
+                        title = "Accept",
+                        description = "Description of whatever the user is accepting",
+                        isSelected = isSelected,
+                        isEnabled = true,
+                        style = style,
+                        onClick = {
+                            isSelected = !isSelected
+                        },
+                    )
+                }
+                Section("Selected enabled") {
+
+                    var isSelected by rememberSaveable { mutableStateOf(true) }
+
+                    SatsChoiceBox(
+                        title = "Accept",
+                        description = "Description of whatever the user is accepting",
+                        isSelected = isSelected,
+                        isEnabled = true,
+                        style = style,
+                        onClick = {
+                            isSelected = !isSelected
+                        },
+                    )
+                }
+
+                Section("Unselected disabled") {
+
+                    var isSelected by rememberSaveable { mutableStateOf(false) }
+
+                    SatsChoiceBox(
+                        title = "Accept",
+                        description = "Description of whatever the user is accepting",
+                        isSelected = isSelected,
+                        isEnabled = false,
+                        style = style,
+                        onClick = {
+                            isSelected = !isSelected
+                        },
+                    )
+                }
+                Section("Selected disabled") {
+                    var isSelected by rememberSaveable { mutableStateOf(true) }
+
+                    SatsChoiceBox(
+                        title = "Accept",
+                        description = "Description of whatever the user is accepting",
+                        isSelected = isSelected,
+                        isEnabled = false,
+                        style = style,
+                        onClick = {
+                            isSelected = !isSelected
+                        },
+                    )
+                }
+                Row(
+                    Modifier.height(IntrinsicSize.Min)
+                ) {
+                    Column(
+                        Modifier.weight(1f),
+                    ) {
+                        Row(
+                            Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Radio",
+                            )
+                            SatsRadioButton(
+                                onClick = {
+                                    style = style.copy(choiceType = SatsChoiceBoxType.Radio)
+                                },
+                                selected = style.choiceType == SatsChoiceBoxType.Radio,
+                            )
+                        }
+                        Row(
+                            Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Check box",
+                            )
+                            SatsRadioButton(
+                                onClick = {
+                                    style = style.copy(choiceType = SatsChoiceBoxType.Checkbox)
+                                },
+                                selected = style.choiceType == SatsChoiceBoxType.Checkbox,
+                            )
+                        }
+                    }
+                    SatsVerticalDivider(Modifier.padding(SatsTheme.spacing.xs))
+                    Column(
+                        Modifier.weight(1f).padding(start = SatsTheme.spacing.s),
+                    ) {
+                        Row(
+                            Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Default colors",
+                            )
+                            SatsRadioButton(
+                                onClick = {
+                                    style = style.copy(color = SatsChoiceBoxColor.Default)
+                                },
+                                selected = style.color == SatsChoiceBoxColor.Default,
+                            )
+                        }
+                        Row(
+                            Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Fixed Colors",
+                            )
+                            SatsRadioButton(
+                                onClick = {
+                                    style = style.copy(color = SatsChoiceBoxColor.Fixed)
+                                },
+                                selected = style.color == SatsChoiceBoxColor.Fixed,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Section(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
+    ) {
+        Text(title, style = SatsTheme.typography.medium.headline3)
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            content()
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ChoiceBoxSampleScreenPreview() {
+    SatsTheme {
+        SatsSurface {
+            ChoiceBoxSampleScreen(
+                navigateUp = {},
+            )
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
@@ -447,6 +448,22 @@ private fun SatsChoiceBoxFixedSelectedPreview() {
                     ),
                 )
             }
+        }
+    }
+}
+
+@PreviewFontScale
+@Composable
+private fun SatsChoiceBoxFontScalePreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.backgrounds.primary.default.bg) {
+            SatsChoiceBox(
+                title = "Accept",
+                description = "This is a description of the choice to be taken",
+                isSelected = true,
+                onClick = {},
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+            )
         }
     }
 }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -41,13 +41,17 @@ fun SatsChoiceBox(
             )
             .clip(SatsTheme.shapes.roundedCorners.small)
             .then(
-                if (isEnabled) Modifier.clickable(
-                    onClick = { onClick(!isSelected) },
-                    role = when (style.choiceType) {
-                        SatsChoiceBoxType.Radio -> Role.RadioButton
-                        SatsChoiceBoxType.Checkbox -> Role.Checkbox
-                    },
-                ) else Modifier,
+                if (isEnabled) {
+                    Modifier.clickable(
+                        onClick = { onClick(!isSelected) },
+                        role = when (style.choiceType) {
+                            SatsChoiceBoxType.Radio -> Role.RadioButton
+                            SatsChoiceBoxType.Checkbox -> Role.Checkbox
+                        },
+                    )
+                } else {
+                    Modifier
+                },
             ),
         color = colors.backgroundColor,
     ) {
@@ -107,17 +111,17 @@ private data class SatsChoiceBoxColors(
 
 data class SatsChoiceBoxStyle(
     val choiceType: SatsChoiceBoxType = SatsChoiceBoxType.Radio,
-    val color: SatsChoiceBoxColor = SatsChoiceBoxColor.Default, // Add colors directly here? 🤔
+    val color: SatsChoiceBoxColor = SatsChoiceBoxColor.Default,
 )
 
 enum class SatsChoiceBoxType {
     Radio,
-    Checkbox
+    Checkbox,
 }
 
 enum class SatsChoiceBoxColor {
     Fixed,
-    Default
+    Default,
 }
 
 @Composable

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -1,0 +1,437 @@
+package com.sats.dna.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.sats.dna.theme.SatsTheme
+
+@Composable
+fun SatsChoiceBox(
+    title: String,
+    description: String,
+    isSelected: Boolean,
+    onClick: (isSelected: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    style: SatsChoiceBoxStyle = SatsChoiceBoxStyle(),
+    isEnabled: Boolean = true,
+) {
+
+    val colors = style.color.getSatsChoiceBoxColors(
+        isEnabled = isEnabled,
+        isSelected = isSelected,
+    )
+
+    SatsSurface(
+        modifier
+            .border(
+                width = 2.dp,
+                color = colors.borderColor,
+                shape = SatsTheme.shapes.roundedCorners.small,
+            )
+            .clip(SatsTheme.shapes.roundedCorners.small)
+            .clickable(
+                onClick = { onClick(!isSelected) },
+                role = when (style.choiceType) {
+                    SatsChoiceBoxType.Radio -> Role.RadioButton
+                    SatsChoiceBoxType.Checkbox -> Role.Checkbox
+                },
+            ),
+        color = colors.backgroundColor,
+    ) {
+        Column(
+            Modifier.padding(start = SatsTheme.spacing.s, bottom = SatsTheme.spacing.s),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    modifier = Modifier.padding(
+                        top = SatsTheme.spacing.m,
+                        end = SatsTheme.spacing.s,
+                    ),
+                    text = title,
+                    style = SatsTheme.typography.emphasis.large,
+                    color = colors.titleColor,
+                )
+
+                if (style.choiceType == SatsChoiceBoxType.Radio) {
+                    SatsRadioButton(
+                        selected = isSelected,
+                        enabled = isEnabled,
+                        onClick = {},
+                    )
+                } else {
+                    SatsCheckbox(
+                        modifier = Modifier.padding(SatsTheme.spacing.s),
+                        checked = isSelected,
+                        enabled = isEnabled,
+                        colors = if (style.color == SatsChoiceBoxColor.Fixed) SatsCheckboxColors.Fixed else SatsCheckboxColors.Primary,
+                        onCheckedChange = null,
+                    )
+                }
+            }
+            Text(
+                modifier = Modifier.padding(end = SatsTheme.spacing.s),
+                text = description,
+                color = colors.descriptionColor,
+            )
+        }
+    }
+}
+
+private data class SatsChoiceBoxColors(
+    val backgroundColor: Color,
+    val borderColor: Color,
+    val titleColor: Color,
+    val descriptionColor: Color,
+)
+
+data class SatsChoiceBoxStyle(
+    val choiceType: SatsChoiceBoxType = SatsChoiceBoxType.Radio,
+    val color: SatsChoiceBoxColor = SatsChoiceBoxColor.Default,
+)
+
+enum class SatsChoiceBoxType {
+    Radio,
+    Checkbox
+}
+
+enum class SatsChoiceBoxColor {
+    Fixed,
+    Default
+}
+
+@Composable
+private fun SatsChoiceBoxColor.getSatsChoiceBoxColors(
+    isEnabled: Boolean,
+    isSelected: Boolean,
+): SatsChoiceBoxColors {
+    return when {
+        isEnabled && isSelected -> selected
+        isEnabled && !isSelected -> unselected
+        !isEnabled && isSelected -> selectedDisabled
+        else -> unselectedDisabled
+    }
+}
+
+private val SatsChoiceBoxColor.unselected: SatsChoiceBoxColors
+    @Composable get() = when (this) {
+        SatsChoiceBoxColor.Default -> SatsChoiceBoxColors(
+            backgroundColor = Color.Transparent,
+            borderColor = SatsTheme.colors.graphicalElements.selector.primary.unselected.default.outline,
+            descriptionColor = SatsTheme.colors.backgrounds.primary.default.fgAlternate,
+            titleColor = SatsTheme.colors.backgrounds.primary.default.fg,
+        )
+
+        SatsChoiceBoxColor.Fixed -> SatsChoiceBoxColors(
+            backgroundColor = Color.Transparent,
+            borderColor = SatsTheme.colors.graphicalElements.selectorFixed.unselected.default.outline,
+            descriptionColor = SatsTheme.colors.backgrounds.fixed.primary.default.fg,
+            titleColor = SatsTheme.colors.backgrounds.fixed.primary.default.fg,
+        )
+    }
+
+private val SatsChoiceBoxColor.selected: SatsChoiceBoxColors
+    @Composable get() = when (this) {
+        SatsChoiceBoxColor.Default -> SatsChoiceBoxColors(
+            backgroundColor = SatsTheme.colors.graphicalElements.selector.primary.selectedSurface.default,
+            borderColor = SatsTheme.colors.graphicalElements.selector.primary.selected.default.bg,
+            descriptionColor = SatsTheme.colors.backgrounds.primary.default.fgAlternate,
+            titleColor = SatsTheme.colors.backgrounds.primary.default.fg,
+        )
+
+        SatsChoiceBoxColor.Fixed -> SatsChoiceBoxColors(
+            backgroundColor = SatsTheme.colors.graphicalElements.selectorFixed.selectedBackground.default,
+            borderColor = SatsTheme.colors.graphicalElements.selectorFixed.selected.default.bg,
+            titleColor = SatsTheme.colors.backgrounds.fixed.primary.default.fg,
+            descriptionColor = SatsTheme.colors.backgrounds.fixed.primary.default.fgAlternate,
+        )
+    }
+
+private val SatsChoiceBoxColor.unselectedDisabled: SatsChoiceBoxColors
+    @Composable get() = when (this) {
+        SatsChoiceBoxColor.Default -> SatsChoiceBoxColors(
+            backgroundColor = Color.Transparent,
+            borderColor = SatsTheme.colors.graphicalElements.selector.primary.unselected.disabled.outline,
+            descriptionColor = SatsTheme.colors.backgrounds.primary.default.fgDisabled,
+            titleColor = SatsTheme.colors.backgrounds.primary.default.fgDisabled,
+        )
+
+        SatsChoiceBoxColor.Fixed -> SatsChoiceBoxColors(
+            backgroundColor = Color.Transparent,
+            borderColor = SatsTheme.colors.graphicalElements.selectorFixed.unselected.disabled.outline,
+            descriptionColor = SatsTheme.colors.backgrounds.fixed.primary.default.fgDisabled,
+            titleColor = SatsTheme.colors.backgrounds.fixed.primary.default.fgDisabled,
+        )
+    }
+
+private val SatsChoiceBoxColor.selectedDisabled: SatsChoiceBoxColors
+    @Composable get() = when (this) {
+        SatsChoiceBoxColor.Default -> SatsChoiceBoxColors(
+            backgroundColor = SatsTheme.colors.graphicalElements.selector.primary.selectedSurface.disabled,
+            borderColor = SatsTheme.colors.graphicalElements.selector.primary.selected.disabled.bg,
+            titleColor = SatsTheme.colors.backgrounds.primary.default.fgDisabled,
+            descriptionColor = SatsTheme.colors.backgrounds.primary.default.fgDisabled,
+        )
+
+        SatsChoiceBoxColor.Fixed -> SatsChoiceBoxColors(
+            backgroundColor = SatsTheme.colors.graphicalElements.selectorFixed.selectedBackground.disabled,
+            borderColor = SatsTheme.colors.graphicalElements.selectorFixed.selected.disabled.fg,
+            titleColor = SatsTheme.colors.backgrounds.fixed.primary.default.fgDisabled,
+            descriptionColor = SatsTheme.colors.backgrounds.fixed.primary.default.fgDisabled,
+        )
+    }
+
+@PreviewLightDark
+@Composable
+private fun SatsChoiceBoxDefaultUnselectedPreview() {
+    SatsTheme {
+        SatsSurface(
+            color = SatsTheme.colors.backgrounds.primary.default.bg,
+        ) {
+            Column(
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            ) {
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsChoiceBoxDefaultSelectedPreview() {
+    SatsTheme {
+        SatsSurface(
+            color = SatsTheme.colors.backgrounds.primary.default.bg,
+        ) {
+            Column(
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            ) {
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Default,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsChoiceBoxFixedUnselectedPreview() {
+    SatsTheme {
+        SatsSurface(
+            color = SatsTheme.colors.backgrounds.fixed.primary.default.bg,
+        ) {
+            Column(
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            ) {
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = false,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun SatsChoiceBoxFixedSelectedPreview() {
+    SatsTheme {
+        SatsSurface(
+            color = SatsTheme.colors.backgrounds.fixed.primary.default.bg,
+        ) {
+            Column(
+                modifier = Modifier.padding(SatsTheme.spacing.m),
+                verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.m),
+            ) {
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Radio,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = true,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+                SatsChoiceBox(
+                    title = "Accept",
+                    description = "This is a description of the choice to be taken",
+                    isSelected = true,
+                    isEnabled = false,
+                    onClick = {},
+                    style = SatsChoiceBoxStyle(
+                        choiceType = SatsChoiceBoxType.Checkbox,
+                        color = SatsChoiceBoxColor.Fixed,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -27,7 +27,6 @@ fun SatsChoiceBox(
     style: SatsChoiceBoxStyle = SatsChoiceBoxStyle(),
     isEnabled: Boolean = true,
 ) {
-
     val colors = style.color.getSatsChoiceBoxColors(
         isEnabled = isEnabled,
         isSelected = isSelected,
@@ -41,12 +40,14 @@ fun SatsChoiceBox(
                 shape = SatsTheme.shapes.roundedCorners.small,
             )
             .clip(SatsTheme.shapes.roundedCorners.small)
-            .clickable(
-                onClick = { onClick(!isSelected) },
-                role = when (style.choiceType) {
-                    SatsChoiceBoxType.Radio -> Role.RadioButton
-                    SatsChoiceBoxType.Checkbox -> Role.Checkbox
-                },
+            .then(
+                if (isEnabled) Modifier.clickable(
+                    onClick = { onClick(!isSelected) },
+                    role = when (style.choiceType) {
+                        SatsChoiceBoxType.Radio -> Role.RadioButton
+                        SatsChoiceBoxType.Checkbox -> Role.Checkbox
+                    },
+                ) else Modifier,
             ),
         color = colors.backgroundColor,
     ) {
@@ -71,15 +72,20 @@ fun SatsChoiceBox(
                     SatsRadioButton(
                         selected = isSelected,
                         enabled = isEnabled,
-                        onClick = {},
+                        onClick = { onClick(!isSelected) },
                     )
                 } else {
                     SatsCheckbox(
-                        modifier = Modifier.padding(SatsTheme.spacing.s),
                         checked = isSelected,
                         enabled = isEnabled,
-                        colors = if (style.color == SatsChoiceBoxColor.Fixed) SatsCheckboxColors.Fixed else SatsCheckboxColors.Primary,
-                        onCheckedChange = null,
+                        colors = if (style.color == SatsChoiceBoxColor.Fixed) {
+                            SatsCheckboxColors.Fixed
+                        } else {
+                            SatsCheckboxColors.Primary
+                        },
+                        onCheckedChange = {
+                            onClick(!isSelected)
+                        },
                     )
                 }
             }
@@ -101,7 +107,7 @@ private data class SatsChoiceBoxColors(
 
 data class SatsChoiceBoxStyle(
     val choiceType: SatsChoiceBoxType = SatsChoiceBoxType.Radio,
-    val color: SatsChoiceBoxColor = SatsChoiceBoxColor.Default,
+    val color: SatsChoiceBoxColor = SatsChoiceBoxColor.Default, // Add colors directly here? 🤔
 )
 
 enum class SatsChoiceBoxType {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -76,6 +76,11 @@ fun SatsChoiceBox(
                     SatsRadioButton(
                         selected = isSelected,
                         enabled = isEnabled,
+                        color = if (style.color == SatsChoiceBoxColor.Fixed) {
+                            SatsRadioButtonColors.Fixed
+                        } else {
+                            SatsRadioButtonColors.Primary
+                        },
                         onClick = { onClick(!isSelected) },
                     )
                 } else {


### PR DESCRIPTION
### What's new?

* Create a SatsChoiceBox component from the design system [here](https://www.figma.com/design/Nu1V7557V7KovgpZCNDObQ/%F0%9F%93%B1-sats-app-components?node-id=4475-6511&t=YSySFsrE8HE9ZaUi-4) 

- [x] Dependent on [this](https://hfnswedenab.atlassian.net/browse/NMA-6798) to get correct colors for the radio buttons.

**Screenshots:**

| Type | Light  | Dark | Fixed |
| ----------- | ----------- | ----------- | ----------- |
| Checkbox |  ![Screenshot_20240607_112539](https://github.com/sats-group/sats-dna-android/assets/48335680/97000ec0-56c7-49e4-9c80-1f1eb4aa863b)  | ![Screenshot_20240607_112559](https://github.com/sats-group/sats-dna-android/assets/48335680/9ac8007f-d982-47c4-adb1-684be91bac7d) | ![Screenshot_20240607_112544](https://github.com/sats-group/sats-dna-android/assets/48335680/7b562ef8-b0b6-4f28-8d94-5cd166f0a386) |
| Radio | ![Screenshot_20240607_112532](https://github.com/sats-group/sats-dna-android/assets/48335680/5ccb36a1-e1d4-46eb-9180-0a4488a48acd) | ![Screenshot_20240607_112554](https://github.com/sats-group/sats-dna-android/assets/48335680/2ae7eb0e-510c-4092-8f84-daf762fdc04e) | ![Screenshot_20240607_112526](https://github.com/sats-group/sats-dna-android/assets/48335680/6cede1a6-5391-4d75-864f-a3fec60335ed) |







