### PR TITLE
NMA-6806: Add Fixed color variant to SatsRadioButtons

### DIFF
--- a/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/RadioButtonsSampleScreen.kt
+++ b/sample-app/src/main/kotlin/com/sats/dna/sample/screens/components/RadioButtonsSampleScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Text
@@ -12,6 +13,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.sats.dna.components.SatsRadioButton
+import com.sats.dna.components.SatsRadioButtonColors
+import com.sats.dna.components.SatsSurface
 import com.sats.dna.sample.screens.SampleScreen
 import com.sats.dna.theme.SatsTheme
 
@@ -26,21 +29,94 @@ fun RadioButtonsSampleScreen(navigateUp: () -> Unit, modifier: Modifier = Modifi
                 .wrapContentSize(),
             Arrangement.spacedBy(SatsTheme.spacing.m, Alignment.CenterVertically),
         ) {
-            LabeledRadioButton("Enabled, unselected", enabled = true, selected = false)
-            LabeledRadioButton("Enabled, selected", enabled = true, selected = true)
-            LabeledRadioButton("Disabled, unselected", enabled = false, selected = false)
-            LabeledRadioButton("Disabled, selected", enabled = false, selected = true)
+            Section("Primary colors") {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                ) {
+                    LabeledRadioButton("Enabled, unselected", enabled = true, selected = false)
+                    LabeledRadioButton("Enabled, selected", enabled = true, selected = true)
+                    LabeledRadioButton("Disabled, unselected", enabled = false, selected = false)
+                    LabeledRadioButton("Disabled, selected", enabled = false, selected = true)
+                }
+            }
+            Section(
+                label = "Fixed colors",
+                isFixedBackground = true,
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+                ) {
+                    LabeledRadioButton(
+                        label = "Enabled, unselected",
+                        enabled = true,
+                        colors = SatsRadioButtonColors.Fixed,
+                        selected = false,
+                    )
+                    LabeledRadioButton(
+                        label = "Enabled, selected",
+                        enabled = true,
+                        colors = SatsRadioButtonColors.Fixed,
+                        selected = true,
+                    )
+                    LabeledRadioButton(
+                        label = "Disabled, unselected",
+                        enabled = false,
+                        colors = SatsRadioButtonColors.Fixed,
+                        selected = false,
+                    )
+                    LabeledRadioButton(
+                        label = "Disabled, selected",
+                        enabled = false,
+                        colors = SatsRadioButtonColors.Fixed,
+                        selected = true,
+                    )
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun LabeledRadioButton(label: String, enabled: Boolean, selected: Boolean) {
+private fun Section(
+    label: String,
+    isFixedBackground: Boolean = false,
+    content: @Composable () -> Unit,
+) {
+    val color = if (isFixedBackground) {
+        SatsTheme.colors.backgrounds.fixed.primary.default.bg
+    } else {
+        SatsTheme.colors.surfaces.primary.default.bg
+    }
+
+    SatsSurface(Modifier.fillMaxWidth(), color = color, shape = SatsTheme.shapes.roundedCorners.medium) {
+        Column(
+            modifier = Modifier.padding(SatsTheme.spacing.s),
+            verticalArrangement = Arrangement.spacedBy(SatsTheme.spacing.xs),
+        ) {
+            Text(label, style = SatsTheme.typography.satsHeadlineEmphasis.small)
+
+            content()
+        }
+    }
+}
+
+@Composable
+private fun LabeledRadioButton(
+    label: String,
+    enabled: Boolean,
+    selected: Boolean,
+    colors: SatsRadioButtonColors = SatsRadioButtonColors.Primary,
+) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(SatsTheme.spacing.s),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        SatsRadioButton(selected, null, enabled = enabled)
+        SatsRadioButton(
+            selected = selected,
+            onClick = null,
+            color = colors,
+            enabled = enabled,
+        )
 
         Text(label)
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsRadioButton.kt
@@ -13,21 +13,40 @@ fun SatsRadioButton(
     selected: Boolean,
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    color: SatsRadioButtonColors = SatsRadioButtonColors.Primary,
     enabled: Boolean = true,
 ) {
-    RadioButton(selected, onClick, modifier, enabled, colors = colors)
+    RadioButton(selected, onClick, modifier, enabled, colors = color.colors)
 }
 
-private val colors: RadioButtonColors
-    @Composable get() {
-        val primary = SatsTheme.colors.graphicalElements.selector.primary
+enum class SatsRadioButtonColors {
+    Primary,
+    Fixed,
+}
 
-        return RadioButtonDefaults.colors(
-            selectedColor = primary.selected.default.bg,
-            unselectedColor = primary.unselected.default.outline,
-            disabledSelectedColor = primary.selected.disabled.bg,
-            disabledUnselectedColor = primary.unselected.disabled.outline,
-        )
+private val SatsRadioButtonColors.colors: RadioButtonColors
+    @Composable get() = when (this) {
+        SatsRadioButtonColors.Primary -> {
+            val primary = SatsTheme.colors.graphicalElements.selector.primary
+
+            RadioButtonDefaults.colors(
+                selectedColor = primary.selected.default.bg,
+                unselectedColor = primary.unselected.default.outline,
+                disabledSelectedColor = primary.selected.disabled.bg,
+                disabledUnselectedColor = primary.unselected.disabled.outline,
+            )
+        }
+
+        SatsRadioButtonColors.Fixed -> {
+            val fixed = SatsTheme.colors.graphicalElements.selectorFixed
+
+            RadioButtonDefaults.colors(
+                selectedColor = fixed.selected.default.bg,
+                unselectedColor = fixed.unselected.default.outline,
+                disabledSelectedColor = fixed.selected.disabled.bg,
+                disabledUnselectedColor = fixed.unselected.disabled.outline,
+            )
+        }
     }
 
 @PreviewLightDark
@@ -66,6 +85,64 @@ private fun DisabledUnselectedPreview() {
     SatsTheme {
         SatsSurface(color = SatsTheme.colors.backgrounds.primary.default.bg) {
             SatsRadioButton(selected = false, onClick = {}, enabled = false)
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun EnabledSelectedFixedPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.backgrounds.fixed.primary.default.bg) {
+            SatsRadioButton(
+                selected = true,
+                color = SatsRadioButtonColors.Fixed,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun EnabledUnselectedFixedPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.backgrounds.fixed.primary.default.bg) {
+            SatsRadioButton(
+                selected = false,
+                color = SatsRadioButtonColors.Fixed,
+                onClick = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DisabledSelectedFixedPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.backgrounds.fixed.primary.default.bg) {
+            SatsRadioButton(
+                selected = true,
+                onClick = {},
+                color = SatsRadioButtonColors.Fixed,
+                enabled = false,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DisabledUnselectedFixedPreview() {
+    SatsTheme {
+        SatsSurface(color = SatsTheme.colors.backgrounds.fixed.primary.default.bg) {
+            SatsRadioButton(
+                selected = false,
+                onClick = {},
+                color = SatsRadioButtonColors.Fixed,
+                enabled = false,
+            )
         }
     }
 }


### PR DESCRIPTION
### What's new?
* Add fixed color variant of the radio buttons as per the [design system](https://www.figma.com/design/Nu1V7557V7KovgpZCNDObQ/%F0%9F%93%B1-sats-app-components?node-id=4990-2610&t=YSySFsrE8HE9ZaUi-4)

**Screenshot**
<img src=https://github.com/sats-group/sats-dna-android/assets/48335680/e372d247-0232-415f-adc0-a816c7dda8b5 width=40%/>