### PR TITLE
NMA-6755: Create a more customisable SatsFancyTopAppBar

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
@@ -145,8 +145,6 @@ fun SatsFancyTopAppBar(
 ) {
     val expandFraction = scrollConnection?.expandFraction ?: 1f
 
-    EnsureStatusBarContrast(expandFraction)
-
     var isStateInitializedWithSize by rememberSaveable { mutableStateOf(false) }
 
     val draggableModifier = if (scrollConnection != null) {

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
@@ -159,7 +159,8 @@ fun SatsFancyTopAppBar(
             val actualWidth = constraints.maxWidth
             val collapsedHeight = collapsedContentPlaceable.height.toFloat()
 
-            // Height of the app bar in total when expanded, we need this to make sure expanded.height >= collapsed.height
+            // Height of the app bar in total when expanded,
+            // We need this to make sure expanded.height >= collapsed.height
             // Which it might not be in case the passed expanded composable has zero or smaller content
             val expandedAppBarHeight = expandedHeaderPlaceable.height + collapsedHeight
 
@@ -320,6 +321,8 @@ class SatsFancyTopAppBarNestedScrollConnection internal constructor() : NestedSc
     internal var currentHeightPx: Float by mutableFloatStateOf(expandedHeightPx)
 
     val expandFraction by derivedStateOf {
+        if (expandedHeightPx - collapsedHeightPx == 0f) return@derivedStateOf 0f
+
         ((currentHeightPx - collapsedHeightPx) / (expandedHeightPx - collapsedHeightPx))
             .coerceIn(minimumValue = 0f, maximumValue = 1f)
     }

--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsFancyTopAppBar.kt
@@ -70,11 +70,11 @@ import com.sats.dna.icons.MoreVertical
 import com.sats.dna.icons.Share
 import com.sats.dna.internal.findActivity
 import com.sats.dna.theme.SatsTheme
-import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 @Composable
 fun SatsFancyTopAppBar(


### PR DESCRIPTION
### What's new?

In challenge details we're gonna tweak the header a bit so we need a version that's a bit more flexible than the previous one. Created a header that will transition between collapsed and expanded content of any kind.

<img src="https://github.com/sats-group/sats-dna-android/assets/48335680/d5607116-f8a8-4109-a0bd-d1544866ad25" width=40%/>

https://github.com/sats-group/sats-dna-android/assets/48335680/7dc38e0b-e6d5-4f6c-a8c0-7389f9c4403e

