### PR TITLE
Prevent SatsChoiceBox button from clipping if text is long

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsChoiceBox.kt
@@ -61,13 +61,12 @@ fun SatsChoiceBox(
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
                     modifier = Modifier.padding(
                         top = SatsTheme.spacing.m,
                         end = SatsTheme.spacing.s,
-                    ),
+                    ).weight(1f),
                     text = title,
                     style = SatsTheme.typography.emphasis.large,
                     color = colors.titleColor,


### PR DESCRIPTION
# Summary

Prevented the button from being pushed out to the side if the text somehow gets long enough that it doesn't fit

# Screenshots

Before and after:

<img src=https://github.com/sats-group/sats-dna-android/assets/91871637/5d847953-1da1-41d2-ac3f-cb117caeabda width=40%> <img src=https://github.com/sats-group/sats-dna-android/assets/91871637/b5a3464f-9207-4f55-b6cf-c4cf4d7a7bc9 width=40%>
