### PR TITLE
NMA-6876: Show completed animated check-mark if in preview

### DIFF
--- a/sats-dna/src/main/kotlin/com/sats/dna/components/SatsAnimatedCheckmark.kt
+++ b/sats-dna/src/main/kotlin/com/sats/dna/components/SatsAnimatedCheckmark.kt
@@ -17,22 +17,30 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.sats.dna.theme.SatsTheme
 
+private val fl = 1f
+
 @Composable
 fun SatsAnimatedCheckmark(modifier: Modifier = Modifier) {
-    val circleSweepAngle = remember { Animatable(0f) }
-    val tickProgress = remember { Animatable(0f) }
+    val isInPreview = LocalInspectionMode.current
+
+    val targetCircleSweepAngle = -360f
+    val targetTickProgress = 1f
+
+    val circleSweepAngle = remember { Animatable(if (isInPreview) targetCircleSweepAngle else 0f) }
+    val tickProgress = remember { Animatable(if (isInPreview) targetTickProgress else 0f) }
 
     LaunchedEffect(null) {
         circleSweepAngle.animateTo(
-            targetValue = -360f,
+            targetValue = targetCircleSweepAngle,
             animationSpec = tween(delayMillis = 200, durationMillis = 500, easing = LinearEasing),
         )
         tickProgress.animateTo(
-            targetValue = 1f,
+            targetValue = targetTickProgress,
             animationSpec = tween(delayMillis = 100, durationMillis = 500, easing = LinearEasing),
         )
     }


### PR DESCRIPTION
| Before | After |
|-|-|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/b9fbba09-67c7-47e2-8760-0954f30275f3)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/cf279979-73eb-4d3d-af4b-bcdadf26cdc7)|
|![image](https://github.com/sats-group/sats-dna-android/assets/386122/ff7e1746-0120-4e50-abea-e74e733d33eb)|![image](https://github.com/sats-group/sats-dna-android/assets/386122/7bb49aff-5298-4d9d-88d7-957411beeef2)|

